### PR TITLE
Issue #26 by omega8cc - Autocomplete breaks on dashes

### DIFF
--- a/lshellmodule/lshell.py
+++ b/lshellmodule/lshell.py
@@ -529,6 +529,7 @@ class ShellCmd(cmd.Cmd, object):
                     readline.read_history_file(self.conf['history_file'])
                 except IOError:
                     pass
+            readline.set_completer_delims(readline.get_completer_delims().replace('-', ''))
             self.old_completer = readline.get_completer()
             readline.set_completer(self.complete)
             readline.parse_and_bind(self.completekey+": complete")
@@ -564,6 +565,7 @@ class ShellCmd(cmd.Cmd, object):
         finally:
             if self.use_rawinput and self.completekey:
                 try:
+                    readline.set_completer_delims(readline.get_completer_delims().replace('-', ''))
                     readline.set_completer(self.old_completer)
                 except ImportError:
                     pass


### PR DESCRIPTION
After reading this issue: http://bugs.python.org/issue10796 I think it should be safe to modify `readline.set_completer_delims` where needed, since it fixes the problem.
