### PR TITLE
Fixed bug when strict=1

### DIFF
--- a/lshellmodule/lshell.py
+++ b/lshellmodule/lshell.py
@@ -474,9 +474,7 @@ class ShellCmd(cmd.Cmd, object):
                         else: 
                             self.log.critical('*** Forbidden path: %s'        \
                                                         % tomatch)
-                            return 1
-                    else:
-                        return 1
+                    return 1
         if not completion:
             if not re.findall(allowed_path_re, os.getcwd()+'/'):
                 if not ssh:
@@ -487,9 +485,7 @@ class ShellCmd(cmd.Cmd, object):
                     else:
                         self.log.critical('*** Forbidden path: %s'            \
                                                         %os.getcwd())
-                        return 1
-                else:
-                    return 1
+                return 1
         return 0
 
     def updateprompt(self, path):


### PR DESCRIPTION
If strict is set to 1 in in lshell.conf then forbidden commands would still get executed.
