### PR TITLE
Fixes 2 security bugs

### DIFF
--- a/lshellmodule/lshell.py
+++ b/lshellmodule/lshell.py
@@ -474,7 +474,7 @@ class ShellCmd(cmd.Cmd, object):
                         else: 
                             self.log.critical('*** Forbidden path: %s'        \
                                                         % tomatch)
-                    return 1
+                return 1
         if not completion:
             if not re.findall(allowed_path_re, os.getcwd()+'/'):
                 if not ssh:


### PR DESCRIPTION
FIX: check_path would not return 1 if strict=1 in lshell.conf so forbidden commands would still execute

FIX: tab-completion would still complete forbidden paths
