### PR TITLE
Wrong parsing &, | or ; characters

### DIFF
--- a/lshellmodule/lshell.py
+++ b/lshellmodule/lshell.py
@@ -474,7 +474,7 @@ class ShellCmd(cmd.Cmd, object):
                         else: 
                             self.log.critical('*** Forbidden path: %s'        \
                                                         % tomatch)
-                    return 1
+                return 1
         if not completion:
             if not re.findall(allowed_path_re, os.getcwd()+'/'):
                 if not ssh:


### PR DESCRIPTION
For example:
$ echo te&st
**\* unknown command: st

$ echo te\&st
**\* unknown command: st

after change
$ echo te&st
**\* unknown command: st

$ echo te\&st
te&st
