### PR TITLE
Fix setup.py with README file extension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ choose a list of allowed commands for every limited account.""",
           packages = ['lshell'],
           data_files = [('/etc', ['etc/lshell.conf']),
                         ('/etc/logrotate.d', ['etc/logrotate.d/lshell']),
-                        ('share/doc/lshell',['README', 'COPYING', 'CHANGES']),
+                        ('share/doc/lshell',['README.md', 'COPYING', 'CHANGES']),
                         ('share/man/man1/', ['man/lshell.1']) ],
           classifiers=[
             'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Setup.py will fail because of markdown extension for README file.
This will fix setup.py with the good name file.
