### PR TITLE
Bugfix with logrotate

### DIFF
--- a/debian/lshell.postinst
+++ b/debian/lshell.postinst
@@ -16,7 +16,7 @@ case "$1" in
     fi
 
     chown root:lshell /var/log/lshell/
-    chmod -R 770 /var/log/lshell/
+    chmod -R 750 /var/log/lshell/
 
     if [ -x /usr/sbin/add-shell ]; then
         add-shell /usr/bin/lshell


### PR DESCRIPTION
Changing rights to avoid this issue with logrotate:

/etc/cron.daily/logrotate:
error: skipping "/var/log/lshell/lshell.log" because parent directory
has insecure permissions (It's world writable or writable by group which
is not "root") Set "su" directive in config file to tell logrotate which
user/group should be used for rotation.