### PR TITLE
[feature] add possibility to disable exit (Closes #156)

### DIFF
--- a/etc/lshell.conf
+++ b/etc/lshell.conf
@@ -137,3 +137,7 @@ strict          : 0
 
 ##  define the script to run at user login
 #login_script     : "/path/to/myscript.sh"
+
+## disable user exit, this could be useful when lshell is spawned from another
+## none-restricted shell (e.g. bash)
+#disable_exit      : 0

--- a/lshell/checkconfig.py
+++ b/lshell/checkconfig.py
@@ -472,6 +472,7 @@ class CheckConfig:
                      'history_size',
                      'login_script',
                      'winscp',
+                     'disable_exit',
                      'quiet']:
             try:
                 if len(self.conf_raw[item]) == 0:

--- a/lshell/shellcmd.py
+++ b/lshell/shellcmd.py
@@ -105,7 +105,8 @@ class ShellCmd(cmd.Cmd, object):
             self.log.error('Exited')
             if self.g_cmd == 'EOF':
                 self.stdout.write('\n')
-            sys.exit(0)
+            if self.conf['disable_exit'] != 1:
+                sys.exit(0)
 
         # check that commands/chars present in line are allowed/secure
         ret_check_secure, self.conf = sec.check_secure(

--- a/lshell/variables.py
+++ b/lshell/variables.py
@@ -87,6 +87,7 @@ configparams = ['config=',
                 'path_noexec=',
                 'allowed_shell_escape=',
                 'winscp=',
+                'disable_exit=',
                 'include_dir=']
 
 builtins_list = ['cd',

--- a/man/lshell.1
+++ b/man/lshell.1
@@ -170,6 +170,10 @@ in the \'allowed\' variable.
 .I allowed_cmd_path
 a list of path; all executable files inside these path will be allowed
 .TP
+.I disable_exit
+disable user exit, this could be useful when lshell is spawned from another
+none-restricted shell (e.g. bash)
+.TP
 .I env_path
 update the environment variable $PATH of the user (optional)
 .TP

--- a/test/test_functional.py
+++ b/test/test_functional.py
@@ -429,5 +429,21 @@ class TestFunctions(unittest.TestCase):
         result = self.child.before.decode('utf8').split('\n', 1)[1]
         self.assertEqual(expected, result)
 
+    def test_31_disable_exit(self):
+        """ F31 | test disabled exit command """
+        self.child = pexpect.spawn('%s/bin/lshell '
+                                   '--config %s/etc/lshell.conf '
+                                   '--disable_exit 1 '
+                                   % (TOPDIR, TOPDIR))
+        self.child.expect('%s:~\$' % self.user)
+
+        expected = u''
+        self.child.sendline('exit')
+        self.child.expect('%s:~\$' % self.user)
+
+        result = self.child.before.decode('utf8').split('\n')[1]
+
+        self.assertIn(expected, result)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added disable_exit flag. If set to 1, it will disable user exit.
This could be useful when lshell is spawned from another
none-restricted shell (e.g. bash)