### PR TITLE
FreeBSD: sudo noexec lib missing path

### DIFF
--- a/lshell/checkconfig.py
+++ b/lshell/checkconfig.py
@@ -750,6 +750,7 @@ class CheckConfig:
                         '/usr/local/lib/sudo_noexec.so',
                         '/usr/local/lib/sudo/sudo_noexec.so',
                         '/usr/local/libexec/sudo_noexec.so',
+                        '/usr/local/libexec/sudo/sudo_noexec.so',
                         '/usr/pkg/libexec/sudo_noexec.so',
                         '/lib64/sudo_noexec.so',
                         '/usr/lib64/sudo/sudo_noexec.so']


### PR DESCRIPTION
The new path of the sudo noexec library was missing from lshell,
making it unable to load it. This create a security issue on FreeBSD.

This commit adds the missing path.