### PR TITLE
Add env_path_before_os_path config parameter (Closes #180)

### DIFF
--- a/etc/lshell.conf
+++ b/etc/lshell.conf
@@ -90,6 +90,9 @@ aliases         : {'ll':'ls -l'}
 ##  update the environment variable $PATH of the user
 #env_path        : ':/usr/local/bin:/usr/sbin'
 
+##  add env_path before OS path in $PATH environment variable
+#env_path_before_os_path : 0
+
 ##  a list of path; all executable files inside these path will be allowed 
 #allowed_cmd_path: ['/home/bla/bin','/home/bla/stuff/libexec']
 

--- a/lshell/checkconfig.py
+++ b/lshell/checkconfig.py
@@ -473,7 +473,8 @@ class CheckConfig:
                      'login_script',
                      'winscp',
                      'disable_exit',
-                     'quiet']:
+                     'quiet',
+                     'env_path_before_os_path']:
             try:
                 if len(self.conf_raw[item]) == 0:
                     self.conf[item] = ""
@@ -575,7 +576,11 @@ class CheckConfig:
             self.conf['history_file'] = "%s/%s" % (self.conf['home_path'],
                                                    self.conf['history_file'])
 
-        os.environ['PATH'] = os.environ['PATH'] + self.conf['env_path']
+        # add env_path at the beginning of the PATH env variable if specified
+        if self.conf['env_path_before_os_path'] is 1:
+            os.environ['PATH'] = self.conf['env_path'] + os.environ['PATH']
+        else:
+            os.environ['PATH'] = os.environ['PATH'] + self.conf['env_path']
 
         # append default commands to allowed list
         self.conf['allowed'] += list(set(variables.builtins_list) -


### PR DESCRIPTION
This adds a new configuration parameter in lshell.conf named `env_path_before_os_path` in order to be able to have the `env_path` config parameter have precedence over the OS path and hence have `env_path` be inserted at the beginning of the `PATH` environment variable.

This is for example required so that rbenv can be used with lshell.