### PR TITLE
Fix permission denied error from logrotate.

### DIFF
--- a/etc/logrotate.d/lshell
+++ b/etc/logrotate.d/lshell
@@ -1,7 +1,7 @@
 # $Id: lshell,v 1.1 2010-03-02 00:05:58 ghantoos Exp $
 
 /var/log/lshell/*.log {
-    su nobody lshell
+    su root lshell
     rotate 12
     weekly
     compress


### PR DESCRIPTION
When tried to logrotate the log I've got a permission denied error:
```
# logrotate -f /etc/logrotate.d/lshell 
error: error opening /var/log/lshell/user1.log: Permission denied
```

```
# ls -l /var/log/lshell/user1.log 
-rw------- 1 user1 sysadmins1 85 Nov 10 10:26 user1.log
```

```
~# id user1
uid=1017(user1) gid=1112(sysadmins1) groups=1112(sysadmins1),3(sys),4(adm),33(www-data),120(lshell)
```

To solve permissions over logrotate, we have to use **root** instead of **nobody** user.
