### PR TITLE
Fix default config (lshell.conf) typos

### DIFF
--- a/etc/lshell.conf
+++ b/etc/lshell.conf
@@ -113,7 +113,7 @@ aliases         : {'ll':'ls -l'}
 #overssh         : ['ls', 'rsync']
 
 ##  logging strictness. If set to 1, any unknown command is considered as 
-##  forbidden, and user's warning counter is decreased. If set to 0, command is
+##  forbidden, and user's warning counter is increased. If set to 0, command is
 ##  considered as unknown, and user is only warned (i.e. *** unknown syntax)
 strict          : 0
 

--- a/etc/lshell.conf
+++ b/etc/lshell.conf
@@ -70,7 +70,7 @@ aliases         : {'ll':'ls -l'}
 ##  introduction text to print (when entering lshell)
 #intro           : "== My personal intro ==\nWelcome to lshell\nType '?' or 'help' to get the list of allowed commands"
 
-##  configure your promt using %u or %h (default: username)
+##  configure your prompt using %u or %h (default: username)
 #prompt          : "%u@%h"
 
 ##  set sort prompt current directory update (default: 0)

--- a/etc/lshell.conf
+++ b/etc/lshell.conf
@@ -114,7 +114,7 @@ aliases         : {'ll':'ls -l'}
 
 ##  logging strictness. If set to 1, any unknown command is considered as 
 ##  forbidden, and user's warning counter is decreased. If set to 0, command is
-##  considered as unknown, and user is only warned (i.e. *** unknown synthax)
+##  considered as unknown, and user is only warned (i.e. *** unknown syntax)
 strict          : 0
 
 ##  force files sent through scp to a specific directory


### PR DESCRIPTION
Small typos:

- synthax -> syntax
- promt -> prompt
- decreased -> increased [warning counter when on strict mode]