### PR TITLE
Feature: update env_path:$PATH (Closes: #180, #181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Contact: [ghantoos@ghantoos.org](mailto:ghantoos@ghantoos.org)  
 [https://github.com/ghantoos/lshell](https://github.com/ghantoos/lshell)
 
+### v0.10.2 24/10/2024
+- Make env_path have precedence over the OS path ($env_path:$PATH)
+- Test auto-release via Pypi
+
 ### v0.10.1 24/10/2024
 - Add the ability to write and execute a lshell script (`#!/usr/bin/lshell`)
 - Added Pypi package

--- a/etc/lshell.conf
+++ b/etc/lshell.conf
@@ -88,7 +88,7 @@ aliases         : {'ll':'ls -l'}
 #home_path       : '/home/bla/'
 
 ##  update the environment variable $PATH of the user
-#env_path        : ':/usr/local/bin:/usr/sbin'
+#env_path        : '/usr/local/bin:/usr/sbin'
 
 ##  a list of path; all executable files inside these path will be allowed 
 #allowed_cmd_path: ['/home/bla/bin','/home/bla/stuff/libexec']

--- a/lshell/checkconfig.py
+++ b/lshell/checkconfig.py
@@ -601,7 +601,17 @@ class CheckConfig:
                 f"{self.conf['home_path']}/{self.conf['history_file']}"
             )
 
-        os.environ["PATH"] = os.environ["PATH"] + self.conf["env_path"]
+        if self.conf["env_path"]:
+            new_path = f"{self.conf['env_path']}:{os.environ['PATH']}"
+
+            # Check if the new path is valid
+            if all(
+                c in string.ascii_letters + string.digits + "/:-_." for c in new_path
+            ) and not new_path.startswith(":"):
+                os.environ["PATH"] = new_path
+            else:
+                print(f"CONF: env_path must be a valid $PATH: {self.conf['env_path']}")
+                sys.exit(1)
 
         # append default commands to allowed list
         self.conf["allowed"] += list(set(variables.builtins_list) - set(["export"]))

--- a/lshell/variables.py
+++ b/lshell/variables.py
@@ -3,7 +3,7 @@
 import sys
 import os
 
-__version__ = "0.10.1"
+__version__ = "0.10.2"
 
 # Required config variable list per user
 required_config = ["allowed", "forbidden", "warning_counter"]

--- a/man/lshell.1
+++ b/man/lshell.1
@@ -1,7 +1,7 @@
 .\"
 .\"   Man page for the Limited Shell (lshell) project.
 .\"
-.TH lshell 1 "October, 2024" "v0.10.1"
+.TH lshell 1 "October, 2024" "v0.10.2"
 
 .SH NAME
 lshell \- Limited Shell


### PR DESCRIPTION
This makes the env_path config parameter have precedence over the OS path and hence have env_path be inserted at the beginning of the PATH environment variable.

Closes: #180 
Closes: #181 

