### PR TITLE
New feature: containment: add runtime limits and optional cgroup targeting

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -2,109 +2,89 @@ name: Publish Python 🐍 distribution 📦 to PyPI
 
 on:
   push:
+    branches:
+    - pre-release
     tags:
-      - "*"
+    - "*"
 
 permissions:
   contents: read
 
 jobs:
-  validate-release-channel:
-    name: Validate release channel
+  publish:
     runs-on: ubuntu-latest
-    outputs:
-      branch_channel: ${{ steps.validate.outputs.branch_channel }}
-      release_type: ${{ steps.validate.outputs.release_type }}
+    permissions:
+      id-token: write
 
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 0
-    - name: Validate tag and branch channel
-      id: validate
-      env:
-        TAG_NAME: ${{ github.ref_name }}
-        TAG_SHA: ${{ github.sha }}
-      run: |
-        set -euo pipefail
-        git fetch --no-tags origin main pre-release
-        TAG_VERSION="${TAG_NAME}"
-        PACKAGE_VERSION="$(python3 -c 'from lshell.variables import __version__; print(__version__)')"
-
-        if [[ "${TAG_VERSION}" != "${PACKAGE_VERSION}" ]]; then
-          echo "Tag/version mismatch: tag=${TAG_VERSION}, package=${PACKAGE_VERSION}" >&2
-          exit 1
-        fi
-
-        if [[ "${TAG_NAME}" == *rc* ]]; then
-          if git merge-base --is-ancestor "${TAG_SHA}" "origin/pre-release"; then
-            echo "branch_channel=pre-release" >> "${GITHUB_OUTPUT}"
-            echo "release_type=release-candidate" >> "${GITHUB_OUTPUT}"
-          else
-            echo "Tag ${TAG_NAME} is an RC but is not based on pre-release." >&2
-            exit 1
-          fi
-        else
-          if git merge-base --is-ancestor "${TAG_SHA}" "origin/main"; then
-            echo "branch_channel=main" >> "${GITHUB_OUTPUT}"
-            echo "release_type=stable" >> "${GITHUB_OUTPUT}"
-          else
-            echo "Tag ${TAG_NAME} is stable but is not based on main." >&2
-            exit 1
-          fi
-        fi
-
-  build:
-    name: Build distribution 📦
-    needs:
-    - validate-release-channel
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v4
+        fetch-depth: 2
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: "3.x"
-    - name: Install pypa/build
-      run: >-
-        python3 -m
-        pip install
-        build
-        --user
-    - name: Build a binary wheel and a source tarball
-      run: python3 -m build
-    - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-
-  publish-to-pypi:
-    name: >-
-      Publish Python 🐍 distribution 📦 to PyPI
-    needs:
-    - validate-release-channel
-    - build
-    runs-on: ubuntu-latest
-
-    environment:
-      name: pypi
-      url: https://pypi.org/p/limited-shell
-    permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
-
-    steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-    - name: Print release channel
+    - name: Decide whether to publish
+      id: decide
       env:
-        RELEASE_TYPE: ${{ needs.validate-release-channel.outputs.release_type }}
-        BRANCH_CHANNEL: ${{ needs.validate-release-channel.outputs.branch_channel }}
+        REF_TYPE: ${{ github.ref_type }}
+        REF_NAME: ${{ github.ref_name }}
+        SHA: ${{ github.sha }}
+        BEFORE_SHA: ${{ github.event.before }}
       run: |
-        echo "Publishing ${GITHUB_REF_NAME} as ${RELEASE_TYPE} from ${BRANCH_CHANNEL}"
+        set -euo pipefail
+        CURRENT_VERSION="$(python3 -c 'from lshell.variables import __version__; print(__version__)')"
+        echo "version=${CURRENT_VERSION}" >> "${GITHUB_OUTPUT}"
+
+        # Official releases: tag is required and must match package version.
+        if [[ "${REF_TYPE}" == "tag" ]]; then
+          if [[ "${REF_NAME}" == "${CURRENT_VERSION}" ]]; then
+            echo "should_publish=true" >> "${GITHUB_OUTPUT}"
+            echo "reason=tag_release" >> "${GITHUB_OUTPUT}"
+          else
+            echo "should_publish=false" >> "${GITHUB_OUTPUT}"
+            echo "reason=tag_version_mismatch" >> "${GITHUB_OUTPUT}"
+          fi
+          exit 0
+        fi
+
+        # Auto RC release from pre-release only when version file changed.
+        if [[ "${REF_NAME}" != "pre-release" ]]; then
+          echo "should_publish=false" >> "${GITHUB_OUTPUT}"
+          echo "reason=not_pre_release_branch" >> "${GITHUB_OUTPUT}"
+          exit 0
+        fi
+
+        if [[ "${CURRENT_VERSION}" != *rc* ]]; then
+          echo "should_publish=false" >> "${GITHUB_OUTPUT}"
+          echo "reason=not_rc_version" >> "${GITHUB_OUTPUT}"
+          exit 0
+        fi
+
+        if [[ -z "${BEFORE_SHA}" || "${BEFORE_SHA}" =~ ^0+$ ]]; then
+          echo "should_publish=false" >> "${GITHUB_OUTPUT}"
+          echo "reason=missing_before_sha" >> "${GITHUB_OUTPUT}"
+          exit 0
+        fi
+
+        if ! git diff --name-only "${BEFORE_SHA}..${SHA}" | grep -qx "lshell/variables.py"; then
+          echo "should_publish=false" >> "${GITHUB_OUTPUT}"
+          echo "reason=version_file_not_changed" >> "${GITHUB_OUTPUT}"
+          exit 0
+        fi
+
+        echo "should_publish=true" >> "${GITHUB_OUTPUT}"
+        echo "reason=rc_version_file_changed" >> "${GITHUB_OUTPUT}"
+    - name: Decision summary
+      run: |
+        echo "should_publish=${{ steps.decide.outputs.should_publish }}"
+        echo "version=${{ steps.decide.outputs.version }}"
+        echo "reason=${{ steps.decide.outputs.reason }}"
+    - name: Build distribution 📦
+      if: steps.decide.outputs.should_publish == 'true'
+      run: |
+        python3 -m pip install --upgrade build
+        python3 -m build
     - name: Publish distribution 📦 to PyPI
+      if: steps.decide.outputs.should_publish == 'true'
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Contact: [ghantoos@ghantoos.org](mailto:ghantoos@ghantoos.org)
 - Added runtime containment `max_sessions_per_user` with lock-protected per-user session accounting and startup enforcement.
 - Added runtime containment `max_background_jobs` enforcement for interactive `&` job creation with denial audit reasons.
 - Added runtime containment `command_timeout` to terminate overlong foreground/background commands and report timeout denials.
+- Added runtime containment `max_processes` with best-effort `RLIMIT_NPROC` enforcement for spawned commands.
 
 ### v0.11.0 10/03/2026
 - Reworked command parsing with a new `pyparsing`-based parser for more reliable command handling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Contact: [ghantoos@ghantoos.org](mailto:ghantoos@ghantoos.org)
 - Changed `harden-init` default output path to `/etc/lshell.d/<profile>.conf`.
 - Enabled `include_dir : /etc/lshell.d/*.conf` in the default `/etc/lshell.conf` template.
 
+### v0.11.1rc3 18/03/2026
+- Added runtime containment `max_sessions_per_user` with lock-protected per-user session accounting and startup enforcement.
+
 ### v0.11.0 10/03/2026
 - Reworked command parsing with a new `pyparsing`-based parser for more reliable command handling.
 - Added policy diagnostics and built-ins: `policy-show`, `policy-path`, and `policy-sudo`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Contact: [ghantoos@ghantoos.org](mailto:ghantoos@ghantoos.org)
 
 ### v0.11.1rc3 18/03/2026
 - Added runtime containment `max_sessions_per_user` with lock-protected per-user session accounting and startup enforcement.
+- Added runtime containment `max_background_jobs` enforcement for interactive `&` job creation with denial audit reasons.
 
 ### v0.11.0 10/03/2026
 - Reworked command parsing with a new `pyparsing`-based parser for more reliable command handling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Contact: [ghantoos@ghantoos.org](mailto:ghantoos@ghantoos.org)
 ### v0.11.1rc3 18/03/2026
 - Added runtime containment `max_sessions_per_user` with lock-protected per-user session accounting and startup enforcement.
 - Added runtime containment `max_background_jobs` enforcement for interactive `&` job creation with denial audit reasons.
+- Added runtime containment `command_timeout` to terminate overlong foreground/background commands and report timeout denials.
 
 ### v0.11.0 10/03/2026
 - Reworked command parsing with a new `pyparsing`-based parser for more reliable command handling.

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Operational notes:
 - `max_background_jobs` denies new `&` jobs once the configured active count is reached.
 - `command_timeout` enforces a per-command wall-clock timeout (foreground and background commands).
 - `max_processes` is applied via POSIX `RLIMIT_NPROC` on spawned command processes.
+- Best practice: keep `command_timeout` enabled whenever `max_processes` is strict (especially `1`).
 
 ### Best practices
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Key settings to review:
 - `messages`
 - `warning_counter`, `strict`
 - `umask`
-- runtime containment: `max_sessions_per_user`
+- runtime containment: `max_sessions_per_user`, `max_background_jobs`
 
 CLI overrides are supported, for example:
 
@@ -155,11 +155,13 @@ Runtime limits are optional and disabled by default when set to `0`.
 
 ```ini
 max_sessions_per_user : 2
+max_background_jobs   : 4
 ```
 
 Operational notes:
 
 - `max_sessions_per_user` is tracked with lock-protected session records; stale entries are cleaned automatically.
+- `max_background_jobs` denies new `&` jobs once the configured active count is reached.
 
 ### Best practices
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Key settings to review:
 - `messages`
 - `warning_counter`, `strict`
 - `umask`
-- runtime containment: `max_sessions_per_user`, `max_background_jobs`
+- runtime containment: `max_sessions_per_user`, `max_background_jobs`, `command_timeout`
 
 CLI overrides are supported, for example:
 
@@ -156,12 +156,14 @@ Runtime limits are optional and disabled by default when set to `0`.
 ```ini
 max_sessions_per_user : 2
 max_background_jobs   : 4
+command_timeout       : 30
 ```
 
 Operational notes:
 
 - `max_sessions_per_user` is tracked with lock-protected session records; stale entries are cleaned automatically.
 - `max_background_jobs` denies new `&` jobs once the configured active count is reached.
+- `command_timeout` enforces a per-command wall-clock timeout (foreground and background commands).
 
 ### Best practices
 

--- a/README.md
+++ b/README.md
@@ -141,12 +141,25 @@ Key settings to review:
 - `messages`
 - `warning_counter`, `strict`
 - `umask`
+- runtime containment: `max_sessions_per_user`
 
 CLI overrides are supported, for example:
 
 ```bash
 lshell --config /path/to/lshell.conf --log /var/log/lshell --umask 0077
 ```
+
+### Runtime containment limits
+
+Runtime limits are optional and disabled by default when set to `0`.
+
+```ini
+max_sessions_per_user : 2
+```
+
+Operational notes:
+
+- `max_sessions_per_user` is tracked with lock-protected session records; stale entries are cleaned automatically.
 
 ### Best practices
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Key settings to review:
 - `messages`
 - `warning_counter`, `strict`
 - `umask`
-- runtime containment: `max_sessions_per_user`, `max_background_jobs`, `command_timeout`
+- runtime containment: `max_sessions_per_user`, `max_background_jobs`, `command_timeout`, `max_processes`
 
 CLI overrides are supported, for example:
 
@@ -157,6 +157,7 @@ Runtime limits are optional and disabled by default when set to `0`.
 max_sessions_per_user : 2
 max_background_jobs   : 4
 command_timeout       : 30
+max_processes         : 64
 ```
 
 Operational notes:
@@ -164,6 +165,7 @@ Operational notes:
 - `max_sessions_per_user` is tracked with lock-protected session records; stale entries are cleaned automatically.
 - `max_background_jobs` denies new `&` jobs once the configured active count is reached.
 - `command_timeout` enforces a per-command wall-clock timeout (foreground and background commands).
+- `max_processes` is applied via POSIX `RLIMIT_NPROC` on spawned command processes.
 
 ### Best practices
 

--- a/etc/lshell.conf
+++ b/etc/lshell.conf
@@ -139,6 +139,8 @@ prompt          : "\033[91m%u\033[97m@\033[96m%h\033[0m"
 #max_background_jobs   : 0
 ##  Wall-clock timeout in seconds per executed command.
 #command_timeout       : 0
+##  Max processes for each spawned command (RLIMIT_NPROC).
+#max_processes         : 0
 
 ##  list of paths to restrict where the user can operate
 ##  warning: commands like vi and less can bypass this restriction

--- a/etc/lshell.conf
+++ b/etc/lshell.conf
@@ -135,6 +135,8 @@ prompt          : "\033[91m%u\033[97m@\033[96m%h\033[0m"
 ##  Runtime containment limits (disabled by default when set to 0):
 ##  Max concurrent lshell sessions for this user.
 #max_sessions_per_user : 0
+##  Max active background jobs (`&`) tracked in this session.
+#max_background_jobs   : 0
 
 ##  list of paths to restrict where the user can operate
 ##  warning: commands like vi and less can bypass this restriction

--- a/etc/lshell.conf
+++ b/etc/lshell.conf
@@ -132,6 +132,10 @@ prompt          : "\033[91m%u\033[97m@\033[96m%h\033[0m"
 ##  a value in seconds for the session timer
 #timer           : 5
 
+##  Runtime containment limits (disabled by default when set to 0):
+##  Max concurrent lshell sessions for this user.
+#max_sessions_per_user : 0
+
 ##  list of paths to restrict where the user can operate
 ##  warning: commands like vi and less can bypass this restriction
 #path            : ['/etc','/var/log','/var/lib']

--- a/etc/lshell.conf
+++ b/etc/lshell.conf
@@ -140,6 +140,8 @@ max_background_jobs   : 0
 ##  Wall-clock timeout in seconds per executed command.
 command_timeout       : 0
 ##  Max processes for each spawned command (RLIMIT_NPROC).
+##  Best practice: keep command_timeout enabled whenever 
+##  max_processes is strict (especially 1).
 max_processes         : 0
 
 ##  list of paths to restrict where the user can operate

--- a/etc/lshell.conf
+++ b/etc/lshell.conf
@@ -137,6 +137,8 @@ prompt          : "\033[91m%u\033[97m@\033[96m%h\033[0m"
 #max_sessions_per_user : 0
 ##  Max active background jobs (`&`) tracked in this session.
 #max_background_jobs   : 0
+##  Wall-clock timeout in seconds per executed command.
+#command_timeout       : 0
 
 ##  list of paths to restrict where the user can operate
 ##  warning: commands like vi and less can bypass this restriction

--- a/etc/lshell.conf
+++ b/etc/lshell.conf
@@ -134,13 +134,13 @@ prompt          : "\033[91m%u\033[97m@\033[96m%h\033[0m"
 
 ##  Runtime containment limits (disabled by default when set to 0):
 ##  Max concurrent lshell sessions for this user.
-#max_sessions_per_user : 0
+max_sessions_per_user : 0
 ##  Max active background jobs (`&`) tracked in this session.
-#max_background_jobs   : 0
+max_background_jobs   : 0
 ##  Wall-clock timeout in seconds per executed command.
-#command_timeout       : 0
+command_timeout       : 0
 ##  Max processes for each spawned command (RLIMIT_NPROC).
-#max_processes         : 0
+max_processes         : 0
 
 ##  list of paths to restrict where the user can operate
 ##  warning: commands like vi and less can bypass this restriction

--- a/lshell/audit.py
+++ b/lshell/audit.py
@@ -98,6 +98,27 @@ def pop_decision_reason(conf, default="policy evaluation failed"):
 
 def log_command_event(conf, command, allowed, reason, level=None):
     """Emit one ECS-aligned command authorization event."""
+    log_security_event(
+        conf,
+        action="command_authorization",
+        allowed=allowed,
+        reason=reason,
+        command=command,
+        level=level,
+        message="lshell command authorization decision",
+    )
+
+
+def log_security_event(
+    conf,
+    action,
+    allowed,
+    reason,
+    command="",
+    level=None,
+    message="lshell security decision",
+):
+    """Emit one ECS-aligned runtime security event."""
     if not enabled(conf):
         return
 
@@ -106,7 +127,7 @@ def log_command_event(conf, command, allowed, reason, level=None):
     log_level = getattr(logging, log_method.upper(), logging.INFO)
     logger.log(
         log_level,
-        "lshell command authorization decision",
+        message,
         extra={
             "session_id": str(conf.get("session_id", "")),
             "source_ip": _source_ip(),
@@ -114,10 +135,10 @@ def log_command_event(conf, command, allowed, reason, level=None):
             "event_kind": "event",
             "event_category": ["authentication", "process"],
             "event_type": ["access"],
-            "event_action": "command_authorization",
+            "event_action": str(action),
             "event_outcome": "success" if allowed else "failure",
             "event_reason": str(reason),
-            "process_command_line": str(command),
+            "process_command_line": str(command or ""),
             "lshell_security_allowed": bool(allowed),
         },
     )

--- a/lshell/builtincmd.py
+++ b/lshell/builtincmd.py
@@ -44,6 +44,13 @@ builtins_list = [
 ]
 
 
+def _cancel_job_timeout(job):
+    """Cancel a watchdog timer attached to a background job, if any."""
+    timer = getattr(job, "lshell_timeout_timer", None)
+    if timer is not None:
+        timer.cancel()
+
+
 def cmd_lpath(conf):
     """Show path policy in a concise, readable format."""
     current_dir = os.path.realpath(os.getcwd())
@@ -200,6 +207,11 @@ def check_background_jobs():
             active_jobs.append(job)
             continue
 
+        _cancel_job_timeout(job)
+        if getattr(job, "lshell_timeout_triggered", False):
+            print(f"[{idx}]+  Timed Out               {_job_command(job)}")
+            continue
+
         status = "Done" if job.returncode == 0 else "Failed"
         args = _job_command(job)
         # only print if the job has not been interrupted by the user
@@ -211,6 +223,8 @@ def check_background_jobs():
 
 def get_job_status(job):
     """Return the status of a background job."""
+    if getattr(job, "lshell_timeout_triggered", False):
+        return "Timed Out"
     if job.poll() is None:
         status = "Stopped"
     elif job.poll() == 0:
@@ -231,6 +245,7 @@ def jobs():
     active_jobs = []
     for job in BACKGROUND_JOBS:
         if job.poll() is not None:
+            _cancel_job_timeout(job)
             continue
 
         active_jobs.append(job)

--- a/lshell/checkconfig.py
+++ b/lshell/checkconfig.py
@@ -571,6 +571,7 @@ class CheckConfig:
             "security_audit_json",
             "max_sessions_per_user",
             "max_background_jobs",
+            "command_timeout",
         ]:
             try:
                 if len(self.conf_raw[item]) == 0:

--- a/lshell/checkconfig.py
+++ b/lshell/checkconfig.py
@@ -20,6 +20,7 @@ from lshell import variables
 from lshell import builtincmd
 from lshell import configschema
 from lshell import audit
+from lshell import containment
 
 
 class CheckConfig:
@@ -568,6 +569,7 @@ class CheckConfig:
             "policy_commands",
             "quiet",
             "security_audit_json",
+            "max_sessions_per_user",
         ]:
             try:
                 if len(self.conf_raw[item]) == 0:
@@ -608,6 +610,12 @@ class CheckConfig:
 
         if self.conf["prompt_short"] not in [0, 1, 2]:
             self.log.critical("lshell: config: 'prompt_short' must be 0, 1, or 2")
+            sys.exit(1)
+
+        try:
+            containment.validate_runtime_config(self.conf)
+        except ValueError as exception:
+            self.log.critical(f"lshell: config: {exception}")
             sys.exit(1)
 
         self.conf["username"] = self.user

--- a/lshell/checkconfig.py
+++ b/lshell/checkconfig.py
@@ -570,6 +570,7 @@ class CheckConfig:
             "quiet",
             "security_audit_json",
             "max_sessions_per_user",
+            "max_background_jobs",
         ]:
             try:
                 if len(self.conf_raw[item]) == 0:

--- a/lshell/checkconfig.py
+++ b/lshell/checkconfig.py
@@ -572,6 +572,7 @@ class CheckConfig:
             "max_sessions_per_user",
             "max_background_jobs",
             "command_timeout",
+            "max_processes",
         ]:
             try:
                 if len(self.conf_raw[item]) == 0:

--- a/lshell/cli.py
+++ b/lshell/cli.py
@@ -9,6 +9,8 @@ import uuid
 from lshell import policy as policy_mode
 from lshell import systemsetup as system_setup
 from lshell import hardeninit as harden_init
+from lshell import audit
+from lshell import containment
 from lshell.checkconfig import CheckConfig
 from lshell.shellcmd import LshellTimeOut, ShellCmd
 
@@ -40,6 +42,24 @@ def main():
     userconf = CheckConfig(args).returnconf()
     userconf["session_id"] = os.environ.get("LSHELL_SESSION_ID", uuid.uuid4().hex)
     os.environ["LSHELL_SESSION_ID"] = userconf["session_id"]
+    session_accountant = containment.SessionAccountant(userconf)
+    try:
+        session_accountant.acquire()
+    except containment.ContainmentViolation as exception:
+        logger = userconf.get("logpath")
+        if logger:
+            logger.critical(exception.log_message)
+        audit.log_security_event(
+            userconf,
+            action="session_start",
+            allowed=False,
+            reason=exception.reason_code,
+            command="lshell startup",
+            level="warning",
+            message="lshell runtime containment decision",
+        )
+        sys.stderr.write(exception.user_message + "\n")
+        sys.exit(1)
 
     def disable_ctrl_z(_signum, _frame):
         return None
@@ -63,3 +83,5 @@ def main():
     except LshellTimeOut:
         userconf["logpath"].error("Timer expired")
         sys.stdout.write("\nTime is up.\n")
+    finally:
+        session_accountant.release()

--- a/lshell/configschema.py
+++ b/lshell/configschema.py
@@ -43,6 +43,7 @@ INT_VALUE_KEYS = {
     "loglevel",
     "security_audit_json",
     "max_sessions_per_user",
+    "max_background_jobs",
 }
 DICT_VALUE_KEYS = {"aliases", "env_vars", "messages"}
 STRING_VALUE_KEYS = {

--- a/lshell/configschema.py
+++ b/lshell/configschema.py
@@ -45,6 +45,7 @@ INT_VALUE_KEYS = {
     "max_sessions_per_user",
     "max_background_jobs",
     "command_timeout",
+    "max_processes",
 }
 DICT_VALUE_KEYS = {"aliases", "env_vars", "messages"}
 STRING_VALUE_KEYS = {

--- a/lshell/configschema.py
+++ b/lshell/configschema.py
@@ -42,6 +42,7 @@ INT_VALUE_KEYS = {
     "quiet",
     "loglevel",
     "security_audit_json",
+    "max_sessions_per_user",
 }
 DICT_VALUE_KEYS = {"aliases", "env_vars", "messages"}
 STRING_VALUE_KEYS = {

--- a/lshell/configschema.py
+++ b/lshell/configschema.py
@@ -44,6 +44,7 @@ INT_VALUE_KEYS = {
     "security_audit_json",
     "max_sessions_per_user",
     "max_background_jobs",
+    "command_timeout",
 }
 DICT_VALUE_KEYS = {"aliases", "env_vars", "messages"}
 STRING_VALUE_KEYS = {

--- a/lshell/containment.py
+++ b/lshell/containment.py
@@ -19,6 +19,7 @@ except ImportError:  # pragma: no cover - non-POSIX fallback.
 RUNTIME_LIMIT_INT_KEYS = (
     "max_sessions_per_user",
     "max_background_jobs",
+    "command_timeout",
 )
 
 _DEFAULT_SESSION_STATE_ROOT = os.path.join(tempfile.gettempdir(), "lshell", "sessions")
@@ -30,6 +31,7 @@ class RuntimeLimits:
 
     max_sessions_per_user: int = 0
     max_background_jobs: int = 0
+    command_timeout: int = 0
 
 
 class ContainmentViolation(Exception):
@@ -72,6 +74,7 @@ def get_runtime_limits(conf):
     return RuntimeLimits(
         max_sessions_per_user=_as_non_negative_int(conf, "max_sessions_per_user"),
         max_background_jobs=_as_non_negative_int(conf, "max_background_jobs"),
+        command_timeout=_as_non_negative_int(conf, "command_timeout"),
     )
 
 

--- a/lshell/containment.py
+++ b/lshell/containment.py
@@ -1,0 +1,273 @@
+"""Runtime containment helpers for per-session guardrails."""
+
+import atexit
+import contextlib
+import errno
+import json
+import os
+import signal
+import tempfile
+import uuid
+from dataclasses import dataclass
+
+try:  # POSIX-only file lock support.
+    import fcntl
+except ImportError:  # pragma: no cover - non-POSIX fallback.
+    fcntl = None
+
+
+RUNTIME_LIMIT_INT_KEYS = ("max_sessions_per_user",)
+
+_DEFAULT_SESSION_STATE_ROOT = os.path.join(tempfile.gettempdir(), "lshell", "sessions")
+
+
+@dataclass(frozen=True)
+class RuntimeLimits:
+    """Resolved runtime limits for one shell session."""
+
+    max_sessions_per_user: int = 0
+
+
+class ContainmentViolation(Exception):
+    """Raised when a containment guardrail denies an action."""
+
+    def __init__(self, reason_code, user_message, log_message):
+        super().__init__(log_message)
+        self.reason_code = reason_code
+        self.user_message = user_message
+        self.log_message = log_message
+
+
+def reason_with_details(reason_code, **details):
+    """Return a machine-readable reason with optional k=v details."""
+    if not details:
+        return reason_code
+    ordered = ",".join(f"{key}={details[key]}" for key in sorted(details))
+    return f"{reason_code} ({ordered})"
+
+
+def _as_non_negative_int(conf, key):
+    value = conf.get(key, 0)
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exception:
+        raise ValueError(f"'{key}' must be an integer") from exception
+    if parsed < 0:
+        raise ValueError(f"'{key}' must be a non-negative integer")
+    return parsed
+
+
+def validate_runtime_config(conf):
+    """Validate runtime containment keys from parsed config."""
+    for key in RUNTIME_LIMIT_INT_KEYS:
+        _as_non_negative_int(conf, key)
+
+
+def get_runtime_limits(conf):
+    """Return parsed runtime limits with disabled defaults."""
+    return RuntimeLimits(
+        max_sessions_per_user=_as_non_negative_int(conf, "max_sessions_per_user"),
+    )
+
+
+def _session_state_root():
+    configured = os.environ.get("LSHELL_SESSION_DIR")
+    if configured:
+        return configured
+    return _DEFAULT_SESSION_STATE_ROOT
+
+
+def _sanitize_component(value):
+    safe = []
+    for char in str(value or ""):
+        if char.isalnum() or char in {".", "_", "-"}:
+            safe.append(char)
+        else:
+            safe.append("_")
+    sanitized = "".join(safe).strip("._")
+    return sanitized or "unknown"
+
+
+def _read_proc_start_time(pid):
+    """Return process start time ticks from /proc when available."""
+    stat_path = f"/proc/{pid}/stat"
+    try:
+        with open(stat_path, "r", encoding="utf-8") as handle:
+            fields = handle.read().split()
+    except OSError:
+        return None
+
+    if len(fields) < 22:
+        return None
+    return fields[21]
+
+
+def _is_pid_alive(pid):
+    try:
+        os.kill(pid, 0)
+    except OSError as exception:
+        if exception.errno == errno.ESRCH:
+            return False
+        if exception.errno == errno.EPERM:
+            return True
+        return False
+    return True
+
+
+def _matches_running_process(record):
+    """Return True when record points to a still-running PID."""
+    try:
+        pid = int(record.get("pid", 0))
+    except (TypeError, ValueError):
+        return False
+
+    if pid <= 0 or not _is_pid_alive(pid):
+        return False
+
+    expected_start = record.get("pid_start")
+    if not expected_start:
+        return True
+
+    current_start = _read_proc_start_time(pid)
+    if current_start is None:
+        return True
+
+    return str(expected_start) == str(current_start)
+
+
+class SessionAccountant:
+    """Track active shell sessions per user using lock-protected files."""
+
+    def __init__(self, conf):
+        self.conf = conf
+        self.limits = get_runtime_limits(conf)
+        self.username = str(conf.get("username") or os.environ.get("USER") or "unknown")
+        self.session_id = str(conf.get("session_id") or uuid.uuid4().hex)
+        self.state_root = _session_state_root()
+        self.user_dir = os.path.join(self.state_root, _sanitize_component(self.username))
+        self.session_file = os.path.join(
+            self.user_dir,
+            f"session-{_sanitize_component(self.session_id)}-{os.getpid()}.json",
+        )
+        self._registered = False
+        self._previous_signal_handlers = {}
+
+    @contextlib.contextmanager
+    def _user_lock(self):
+        os.makedirs(self.user_dir, mode=0o700, exist_ok=True)
+        lock_path = os.path.join(self.user_dir, ".lock")
+        lock_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            if fcntl is not None:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            yield
+        finally:
+            if fcntl is not None:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            os.close(lock_fd)
+
+    def _read_session_record(self, path):
+        try:
+            with open(path, "r", encoding="utf-8") as handle:
+                return json.load(handle)
+        except (OSError, json.JSONDecodeError, ValueError):
+            return None
+
+    def _write_session_record(self):
+        payload = {
+            "pid": os.getpid(),
+            "pid_start": _read_proc_start_time(os.getpid()),
+            "session_id": self.session_id,
+            "username": self.username,
+        }
+        with open(self.session_file, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, sort_keys=True)
+
+    def _active_sessions_locked(self):
+        active = []
+        for entry in os.listdir(self.user_dir):
+            if not (entry.startswith("session-") and entry.endswith(".json")):
+                continue
+            path = os.path.join(self.user_dir, entry)
+            record = self._read_session_record(path)
+            if not record or not _matches_running_process(record):
+                with contextlib.suppress(OSError):
+                    os.remove(path)
+                continue
+            active.append(path)
+        return active
+
+    def acquire(self):
+        """Register this session and enforce max concurrent sessions per user."""
+        max_sessions = self.limits.max_sessions_per_user
+        if max_sessions <= 0:
+            return
+
+        with self._user_lock():
+            active_sessions = self._active_sessions_locked()
+            if len(active_sessions) >= max_sessions:
+                reason = reason_with_details(
+                    "runtime_limit.max_sessions_per_user_exceeded",
+                    active=len(active_sessions),
+                    limit=max_sessions,
+                    user=self.username,
+                )
+                raise ContainmentViolation(
+                    reason_code=reason,
+                    user_message=(
+                        "lshell: session denied: "
+                        f"max_sessions_per_user={max_sessions} reached"
+                    ),
+                    log_message=(
+                        "lshell: runtime containment denied session start: "
+                        f"user={self.username}, active={len(active_sessions)}, "
+                        f"limit={max_sessions}"
+                    ),
+                )
+            self._write_session_record()
+
+        if not self._registered:
+            atexit.register(self.release)
+            self._install_signal_handlers()
+            self._registered = True
+
+    def release(self):
+        """Remove this session from accounting storage."""
+        if self.limits.max_sessions_per_user <= 0:
+            return
+
+        if not self.session_file:
+            return
+
+        with contextlib.suppress(OSError):
+            with self._user_lock():
+                with contextlib.suppress(OSError):
+                    os.remove(self.session_file)
+
+        self._restore_signal_handlers()
+
+    def _install_signal_handlers(self):
+        for sig_name in ("SIGHUP", "SIGTERM", "SIGQUIT"):
+            signum = getattr(signal, sig_name, None)
+            if signum is None:
+                continue
+            previous = signal.getsignal(signum)
+            self._previous_signal_handlers[signum] = previous
+            signal.signal(signum, self._signal_cleanup_handler)
+
+    def _restore_signal_handlers(self):
+        for signum, previous in self._previous_signal_handlers.items():
+            with contextlib.suppress(OSError, ValueError):
+                signal.signal(signum, previous)
+        self._previous_signal_handlers.clear()
+
+    def _signal_cleanup_handler(self, signum, frame):
+        self.release()
+        previous = self._previous_signal_handlers.get(signum, signal.SIG_DFL)
+        if callable(previous):
+            previous(signum, frame)
+            return
+        if previous == signal.SIG_IGN:
+            return
+        signal.signal(signum, signal.SIG_DFL)
+        os.kill(os.getpid(), signum)

--- a/lshell/containment.py
+++ b/lshell/containment.py
@@ -15,11 +15,17 @@ try:  # POSIX-only file lock support.
 except ImportError:  # pragma: no cover - non-POSIX fallback.
     fcntl = None
 
+try:  # POSIX rlimits.
+    import resource
+except ImportError:  # pragma: no cover - non-POSIX fallback.
+    resource = None
+
 
 RUNTIME_LIMIT_INT_KEYS = (
     "max_sessions_per_user",
     "max_background_jobs",
     "command_timeout",
+    "max_processes",
 )
 
 _DEFAULT_SESSION_STATE_ROOT = os.path.join(tempfile.gettempdir(), "lshell", "sessions")
@@ -32,6 +38,7 @@ class RuntimeLimits:
     max_sessions_per_user: int = 0
     max_background_jobs: int = 0
     command_timeout: int = 0
+    max_processes: int = 0
 
 
 class ContainmentViolation(Exception):
@@ -75,6 +82,7 @@ def get_runtime_limits(conf):
         max_sessions_per_user=_as_non_negative_int(conf, "max_sessions_per_user"),
         max_background_jobs=_as_non_negative_int(conf, "max_background_jobs"),
         command_timeout=_as_non_negative_int(conf, "command_timeout"),
+        max_processes=_as_non_negative_int(conf, "max_processes"),
     )
 
 
@@ -279,3 +287,58 @@ class SessionAccountant:
             return
         signal.signal(signum, signal.SIG_DFL)
         os.kill(os.getpid(), signum)
+
+
+def apply_rlimits(limits, resource_module=None):
+    """Apply configured rlimits in the current process context."""
+    if resource_module is None:
+        resource_module = resource
+
+    unsupported = []
+    if resource_module is None:
+        if limits.max_processes > 0:
+            unsupported.append("max_processes")
+        return unsupported
+
+    if limits.max_processes > 0:
+        rlimit_nproc = getattr(resource_module, "RLIMIT_NPROC", None)
+        if rlimit_nproc is None:
+            unsupported.append("max_processes")
+        else:
+            try:
+                resource_module.setrlimit(
+                    rlimit_nproc,
+                    (limits.max_processes, limits.max_processes),
+                )
+            except (OSError, ValueError):
+                unsupported.append("max_processes")
+
+    return unsupported
+
+
+def unsupported_rlimits(limits, resource_module=None):
+    """Return containment limit keys unsupported by the current platform."""
+    if resource_module is None:
+        resource_module = resource
+
+    unsupported = []
+    if resource_module is None:
+        if limits.max_processes > 0:
+            unsupported.append("max_processes")
+        return unsupported
+
+    if limits.max_processes > 0 and getattr(resource_module, "RLIMIT_NPROC", None) is None:
+        unsupported.append("max_processes")
+
+    return unsupported
+
+
+def build_preexec_fn(detached_session, limits):
+    """Build subprocess pre-exec hook to apply process/session limits."""
+
+    def _preexec():
+        if detached_session:
+            os.setsid()
+        apply_rlimits(limits)
+
+    return _preexec

--- a/lshell/containment.py
+++ b/lshell/containment.py
@@ -16,7 +16,10 @@ except ImportError:  # pragma: no cover - non-POSIX fallback.
     fcntl = None
 
 
-RUNTIME_LIMIT_INT_KEYS = ("max_sessions_per_user",)
+RUNTIME_LIMIT_INT_KEYS = (
+    "max_sessions_per_user",
+    "max_background_jobs",
+)
 
 _DEFAULT_SESSION_STATE_ROOT = os.path.join(tempfile.gettempdir(), "lshell", "sessions")
 
@@ -26,6 +29,7 @@ class RuntimeLimits:
     """Resolved runtime limits for one shell session."""
 
     max_sessions_per_user: int = 0
+    max_background_jobs: int = 0
 
 
 class ContainmentViolation(Exception):
@@ -67,6 +71,7 @@ def get_runtime_limits(conf):
     """Return parsed runtime limits with disabled defaults."""
     return RuntimeLimits(
         max_sessions_per_user=_as_non_negative_int(conf, "max_sessions_per_user"),
+        max_background_jobs=_as_non_negative_int(conf, "max_background_jobs"),
     )
 
 

--- a/lshell/policy.py
+++ b/lshell/policy.py
@@ -13,6 +13,7 @@ import textwrap
 from getpass import getuser
 
 from lshell import builtincmd
+from lshell import containment
 from lshell import configschema
 from lshell import sec
 from lshell import utils
@@ -375,6 +376,9 @@ def _build_runtime_policy(conf_raw, username):
         if ";" in policy["forbidden"]:
             policy["forbidden"].remove(";")
 
+    runtime_limits = containment.get_runtime_limits(conf_raw)
+    for key in containment.RUNTIME_LIMIT_INT_KEYS:
+        policy[key] = getattr(runtime_limits, key)
     return policy
 
 
@@ -701,11 +705,29 @@ def print_user_view(result, command_line=None, decision=None):
     timer_value = policy.get("timer")
     forbidden = sorted(set(policy.get("forbidden", [])), key=str)
     extensions = policy.get("allowed_file_extensions", [])
+    def _limit_or_unlimited(value, suffix=""):
+        return f"{value}{suffix}" if int(value) > 0 else "Unlimited"
 
     print(_paint("Policy Overview", "bold", color))
     print("-" * 15)
     print(f"Strict mode            : {strict_mode}")
     print(f"Warnings remaining     : {warnings_value}")
+    print(
+        "Max sessions/user      : "
+        + _limit_or_unlimited(policy.get("max_sessions_per_user", 0))
+    )
+    print(
+        "Max background jobs    : "
+        + _limit_or_unlimited(policy.get("max_background_jobs", 0))
+    )
+    print(
+        "Command timeout (sec)  : "
+        + _limit_or_unlimited(policy.get("command_timeout", 0), "s")
+    )
+    print(
+        "Max processes          : "
+        + _limit_or_unlimited(policy.get("max_processes", 0))
+    )
     print("")
 
     print(_paint("Command Access", "bold", color))

--- a/lshell/shellcmd.py
+++ b/lshell/shellcmd.py
@@ -381,58 +381,69 @@ class ShellCmd(cmd.Cmd, object):
             partial_line = ""
             stop = None
             while not stop:
-                # Check background jobs after each command
-                builtincmd.check_background_jobs()
-                if self.cmdqueue:
-                    line = self.cmdqueue.pop(0)
-                else:
-                    if self.use_rawinput:
-                        try:
-                            line = input(self.conf["promptprint"])
-                        except EOFError:
-                            line = "EOF"
-                        except KeyboardInterrupt:
-                            self.stdout.write("\n")
-                            if partial_line:
-                                partial_line = ""
-                                self.conf["promptprint"] = utils.updateprompt(
-                                    os.getcwd(), self.conf
-                                )
-                            continue
+                try:
+                    # Check background jobs after each command
+                    builtincmd.check_background_jobs()
+                    if self.cmdqueue:
+                        line = self.cmdqueue.pop(0)
                     else:
-                        self.stdout.write(self.conf["promptprint"])
-                        self.stdout.flush()
-                        line = self.stdin.readline()
-                        if not line:
-                            line = "EOF"
+                        if self.use_rawinput:
+                            try:
+                                line = input(self.conf["promptprint"])
+                            except EOFError:
+                                line = "EOF"
+                            except KeyboardInterrupt:
+                                self.stdout.write("\n")
+                                if partial_line:
+                                    partial_line = ""
+                                    self.conf["promptprint"] = utils.updateprompt(
+                                        os.getcwd(), self.conf
+                                    )
+                                continue
                         else:
-                            # chop \n
-                            line = line[:-1]
-                    if len(line) > 1 and line.startswith("\\"):
-                        # implying previous partial line
-                        line = line[:1].replace("\\", "", 1)
-                    if partial_line:
-                        line = partial_line + line
-                    if line.endswith("\\"):
-                        # continuation character. First partial line.
-                        # We shall expect the command to continue in
-                        # a new line. Change to bash like PS2 prompt to
-                        # indicate this continuation to the user
-                        partial_line = line.strip("\\")
-                        self.conf["promptprint"] = self.prompt2  # switching to PS2
-                        continue
-                    elif line.count('"') % 2 != 0 or line.count("'") % 2 != 0:
-                        # unclosed quotes detected
-                        partial_line = line
-                        self.conf["promptprint"] = self.prompt2  # switching to PS2
-                        continue
+                            self.stdout.write(self.conf["promptprint"])
+                            self.stdout.flush()
+                            line = self.stdin.readline()
+                            if not line:
+                                line = "EOF"
+                            else:
+                                # chop \n
+                                line = line[:-1]
+                        if len(line) > 1 and line.startswith("\\"):
+                            # implying previous partial line
+                            line = line[:1].replace("\\", "", 1)
+                        if partial_line:
+                            line = partial_line + line
+                        if line.endswith("\\"):
+                            # continuation character. First partial line.
+                            # We shall expect the command to continue in
+                            # a new line. Change to bash like PS2 prompt to
+                            # indicate this continuation to the user
+                            partial_line = line.strip("\\")
+                            self.conf["promptprint"] = self.prompt2  # switching to PS2
+                            continue
+                        elif line.count('"') % 2 != 0 or line.count("'") % 2 != 0:
+                            # unclosed quotes detected
+                            partial_line = line
+                            self.conf["promptprint"] = self.prompt2  # switching to PS2
+                            continue
+                        partial_line = ""
+                        self.conf["promptprint"] = utils.updateprompt(
+                            os.getcwd(), self.conf
+                        )
+                    line = self.precmd(line)
+                    stop = self.onecmd(line)
+                    stop = self.postcmd(stop, line)
+                except KeyboardInterrupt:
+                    # Keep prompt handling local to cmdloop even when Ctrl+C
+                    # races outside input() (e.g. background-job checks).
+                    self.stdout.write("\n")
+                    self.stdout.flush()
                     partial_line = ""
                     self.conf["promptprint"] = utils.updateprompt(
                         os.getcwd(), self.conf
                     )
-                line = self.precmd(line)
-                stop = self.onecmd(line)
-                stop = self.postcmd(stop, line)
+                    continue
             self.postloop()
         finally:
             if self.use_rawinput and self.completekey:

--- a/lshell/shellcmd.py
+++ b/lshell/shellcmd.py
@@ -100,9 +100,6 @@ class ShellCmd(cmd.Cmd, object):
             self.conf["promptprint"] = utils.updateprompt(os.getcwd(), self.conf)
             self.log = self.conf["logpath"]
 
-        if self.g_cmd in ["quit", "exit", "EOF"]:
-            self.do_exit()
-
         if self.conf["timer"] > 0:
             self.mytimer(0)
 
@@ -573,6 +570,14 @@ class ShellCmd(cmd.Cmd, object):
         list_tmp = list(dict.fromkeys(self.completenames("", "")).keys())
         list_tmp.sort()
         self.columnize(list_tmp)
+
+    def do_EOF(self, arg=None):  # pylint: disable=invalid-name
+        """Handle Ctrl+D / EOF exactly like exit."""
+        return self.do_exit(arg)
+
+    def do_quit(self, arg=None):
+        """Handle quit exactly like exit."""
+        return self.do_exit(arg)
 
     def do_policy_show(self, arg=None):
         """Show resolved policy values and optional decision for a command."""

--- a/lshell/utils.py
+++ b/lshell/utils.py
@@ -9,6 +9,7 @@ import random
 import string
 import shlex
 import shutil
+import threading
 from getpass import getuser
 from time import strftime, gmtime
 import signal
@@ -881,6 +882,8 @@ def exec_cmd(cmd, background=False, extra_env=None, conf=None, log=None):
     proc = None
     detached_session = True
     exec_env = dict(os.environ)
+    runtime_limits = containment.get_runtime_limits(conf or {})
+    command_timeout = runtime_limits.command_timeout
     if extra_env:
         exec_env.update(extra_env)
     # Prevent non-interactive shell startup file injection.
@@ -917,6 +920,41 @@ def exec_cmd(cmd, background=False, extra_env=None, conf=None, log=None):
             else:
                 os.kill(proc.pid, signal.SIGCONT)
 
+    def _kill_process_group(target):
+        if not target or target.poll() is not None:
+            return
+        try:
+            if detached_session:
+                os.killpg(os.getpgid(target.pid), signal.SIGKILL)
+            else:
+                os.kill(target.pid, signal.SIGKILL)
+        except OSError:
+            return
+
+    def _timeout_reason():
+        return containment.reason_with_details(
+            "runtime_limit.command_timeout_exceeded",
+            timeout=command_timeout,
+        )
+
+    def _emit_timeout_event():
+        if conf:
+            audit.log_command_event(
+                conf,
+                cmd,
+                allowed=False,
+                reason=_timeout_reason(),
+                level="warning",
+            )
+        if log:
+            log.warning(
+                "lshell: runtime containment timed out command: "
+                f'timeout={command_timeout}s, command="{cmd}"'
+            )
+        sys.stderr.write(
+            f"lshell: command timed out after {command_timeout}s: {cmd}\n"
+        )
+
     previous_sigtstp_handler = signal.getsignal(signal.SIGTSTP)
     previous_sigcont_handler = signal.getsignal(signal.SIGCONT)
 
@@ -945,6 +983,19 @@ def exec_cmd(cmd, background=False, extra_env=None, conf=None, log=None):
                     popen_kwargs["preexec_fn"] = os.setsid
                 proc = subprocess.Popen(cmd_args, **popen_kwargs)
             proc.lshell_cmd = cmd
+            proc.lshell_timeout_timer = None
+            if command_timeout > 0:
+
+                def _background_timeout():
+                    if proc and proc.poll() is None:
+                        proc.lshell_timeout_triggered = True
+                        _kill_process_group(proc)
+                        _emit_timeout_event()
+
+                timeout_timer = threading.Timer(command_timeout, _background_timeout)
+                timeout_timer.daemon = True
+                timeout_timer.start()
+                proc.lshell_timeout_timer = timeout_timer
             # add to background jobs and return
             builtincmd.BACKGROUND_JOBS.append(proc)
             job_id = len(builtincmd.BACKGROUND_JOBS)
@@ -956,7 +1007,10 @@ def exec_cmd(cmd, background=False, extra_env=None, conf=None, log=None):
                 popen_kwargs["preexec_fn"] = os.setsid
             proc = subprocess.Popen(cmd_args, **popen_kwargs)
             proc.lshell_cmd = cmd
-            proc.communicate()
+            if command_timeout > 0:
+                proc.communicate(timeout=command_timeout)
+            else:
+                proc.communicate()
             retcode = proc.returncode if proc.returncode is not None else 0
 
     except FileNotFoundError:
@@ -964,6 +1018,12 @@ def exec_cmd(cmd, background=False, extra_env=None, conf=None, log=None):
             "Command execution failed: required shell interpreter not found.\n"
         )
         retcode = 127
+    except subprocess.TimeoutExpired:
+        _kill_process_group(proc)
+        if proc:
+            proc.communicate()
+        _emit_timeout_event()
+        retcode = 124
     except CtrlZException:  # Handle Ctrl+Z
         retcode = 0
     except KeyboardInterrupt:  # Handle Ctrl+C
@@ -974,6 +1034,12 @@ def exec_cmd(cmd, background=False, extra_env=None, conf=None, log=None):
                 os.kill(proc.pid, signal.SIGINT)
         retcode = 130
     finally:
+        if (
+            proc is not None
+            and getattr(proc, "lshell_timeout_timer", None) is not None
+            and proc.poll() is not None
+        ):
+            proc.lshell_timeout_timer.cancel()
         signal.signal(signal.SIGTSTP, previous_sigtstp_handler)
         signal.signal(signal.SIGCONT, previous_sigcont_handler)
 

--- a/lshell/utils.py
+++ b/lshell/utils.py
@@ -19,6 +19,7 @@ from lshell import builtincmd
 from lshell import sec
 from lshell import messages
 from lshell import audit
+from lshell import containment
 
 
 def usage(exitcode=1):
@@ -498,7 +499,7 @@ def handle_builtin_command(full_command, executable, argument, shell_context):
     elif executable == "cd":
         retcode, shell_context.conf = builtincmd.cmd_cd(argument, shell_context.conf)
     elif executable == "ls":
-        retcode = exec_cmd(full_command)
+        retcode = exec_cmd(full_command, conf=shell_context.conf, log=shell_context.log)
     elif executable in ["lpath", "policy-path"]:
         retcode = builtincmd.cmd_lpath(conf)
     elif executable in ["lsudo", "policy-sudo"]:
@@ -691,6 +692,33 @@ def cmd_parse_execute(command_line, shell_context=None, trusted_protocol=False):
         full_command = " | ".join(pipeline_parts)
         background = bool(j + 1 < len(command_sequence) and command_sequence[j + 1] == "&")
 
+        if background:
+            limits = containment.get_runtime_limits(shell_context.conf)
+            if limits.max_background_jobs > 0:
+                active_jobs = len(builtincmd.jobs())
+                if active_jobs >= limits.max_background_jobs:
+                    reason = containment.reason_with_details(
+                        "runtime_limit.max_background_jobs_exceeded",
+                        active=active_jobs,
+                        limit=limits.max_background_jobs,
+                    )
+                    shell_context.log.critical(
+                        "lshell: runtime containment denied background command: "
+                        f"active_jobs={active_jobs}, limit={limits.max_background_jobs}, "
+                        f'command="{full_command}"'
+                    )
+                    sys.stderr.write(
+                        "lshell: background job denied: "
+                        f"max_background_jobs={limits.max_background_jobs} reached\n"
+                    )
+                    audit.log_command_event(
+                        shell_context.conf,
+                        full_command,
+                        allowed=False,
+                        reason=reason,
+                    )
+                    return 126
+
         parsed_parts = [_parse_command(part) for part in pipeline_parts]
         if any(part[0] is None for part in parsed_parts):
             return _handle_unknown_syntax(full_command)
@@ -833,7 +861,11 @@ def cmd_parse_execute(command_line, shell_context=None, trusted_protocol=False):
                 reason="allowed by command and path policy",
             )
             retcode = exec_cmd(
-                full_command, background=background, extra_env=extra_env
+                full_command,
+                background=background,
+                extra_env=extra_env,
+                conf=shell_context.conf,
+                log=shell_context.log,
             )
         else:
             retcode = _handle_unknown_syntax(full_command)
@@ -844,7 +876,7 @@ def cmd_parse_execute(command_line, shell_context=None, trusted_protocol=False):
     return retcode
 
 
-def exec_cmd(cmd, background=False, extra_env=None):
+def exec_cmd(cmd, background=False, extra_env=None, conf=None, log=None):
     """Execute a command exactly as entered, with support for backgrounding via Ctrl+Z."""
     proc = None
     detached_session = True

--- a/lshell/utils.py
+++ b/lshell/utils.py
@@ -884,6 +884,17 @@ def exec_cmd(cmd, background=False, extra_env=None, conf=None, log=None):
     exec_env = dict(os.environ)
     runtime_limits = containment.get_runtime_limits(conf or {})
     command_timeout = runtime_limits.command_timeout
+    unsupported_limits = containment.unsupported_rlimits(runtime_limits)
+    if conf is not None and log and unsupported_limits:
+        logged_key = "_runtime_unsupported_limits_logged"
+        already_logged = set(conf.get(logged_key, []))
+        pending = [item for item in unsupported_limits if item not in already_logged]
+        if pending:
+            log.warning(
+                "lshell: runtime containment limits unsupported on this platform: "
+                + ", ".join(sorted(pending))
+            )
+            conf[logged_key] = sorted(already_logged.union(pending))
     if extra_env:
         exec_env.update(extra_env)
     # Prevent non-interactive shell startup file injection.
@@ -971,6 +982,10 @@ def exec_cmd(cmd, background=False, extra_env=None, conf=None, log=None):
             cmd_args = split_cmd
             if not background:
                 detached_session = False
+        preexec_fn = None
+        needs_resource_limits = runtime_limits.max_processes > 0
+        if os.name == "posix" and (detached_session or needs_resource_limits):
+            preexec_fn = containment.build_preexec_fn(detached_session, runtime_limits)
         if background:
             with open(os.devnull, "r") as devnull_in:
                 popen_kwargs = {
@@ -979,8 +994,8 @@ def exec_cmd(cmd, background=False, extra_env=None, conf=None, log=None):
                     "stderr": sys.stderr,
                     "env": exec_env,
                 }
-                if detached_session:
-                    popen_kwargs["preexec_fn"] = os.setsid
+                if preexec_fn is not None:
+                    popen_kwargs["preexec_fn"] = preexec_fn
                 proc = subprocess.Popen(cmd_args, **popen_kwargs)
             proc.lshell_cmd = cmd
             proc.lshell_timeout_timer = None
@@ -1003,8 +1018,8 @@ def exec_cmd(cmd, background=False, extra_env=None, conf=None, log=None):
             retcode = 0
         else:
             popen_kwargs = {"env": exec_env}
-            if detached_session:
-                popen_kwargs["preexec_fn"] = os.setsid
+            if preexec_fn is not None:
+                popen_kwargs["preexec_fn"] = preexec_fn
             proc = subprocess.Popen(cmd_args, **popen_kwargs)
             proc.lshell_cmd = cmd
             if command_timeout > 0:
@@ -1024,6 +1039,28 @@ def exec_cmd(cmd, background=False, extra_env=None, conf=None, log=None):
             proc.communicate()
         _emit_timeout_event()
         retcode = 124
+    except subprocess.SubprocessError as exception:
+        reason = containment.reason_with_details(
+            "runtime_limit.preexec_application_failed",
+            error=str(exception),
+        )
+        if conf:
+            audit.log_command_event(
+                conf,
+                cmd,
+                allowed=False,
+                reason=reason,
+                level="warning",
+            )
+        if log:
+            log.critical(
+                "lshell: runtime containment denied command execution: "
+                f"{reason}"
+            )
+        sys.stderr.write(
+            "lshell: command denied: unable to apply runtime containment limits\n"
+        )
+        retcode = 126
     except CtrlZException:  # Handle Ctrl+Z
         retcode = 0
     except KeyboardInterrupt:  # Handle Ctrl+C

--- a/lshell/variables.py
+++ b/lshell/variables.py
@@ -110,6 +110,7 @@ configparams = [
     "include_dir=",
     "security_audit_json=",
     "max_sessions_per_user=",
+    "max_background_jobs=",
 ]
 
 FORBIDDEN_ENVIRON = (

--- a/lshell/variables.py
+++ b/lshell/variables.py
@@ -109,6 +109,7 @@ configparams = [
     "policy_commands=",
     "include_dir=",
     "security_audit_json=",
+    "max_sessions_per_user=",
 ]
 
 FORBIDDEN_ENVIRON = (

--- a/lshell/variables.py
+++ b/lshell/variables.py
@@ -111,6 +111,7 @@ configparams = [
     "security_audit_json=",
     "max_sessions_per_user=",
     "max_background_jobs=",
+    "command_timeout=",
 ]
 
 FORBIDDEN_ENVIRON = (

--- a/lshell/variables.py
+++ b/lshell/variables.py
@@ -112,6 +112,7 @@ configparams = [
     "max_sessions_per_user=",
     "max_background_jobs=",
     "command_timeout=",
+    "max_processes=",
 ]
 
 FORBIDDEN_ENVIRON = (

--- a/man/lshell.1
+++ b/man/lshell.1
@@ -444,6 +444,10 @@ different user than the default root.
 .I timer
 a value in seconds for the session timer
 .TP
+.I max_sessions_per_user
+maximum concurrent lshell sessions for the same user.
+Set to \fB0\fR to disable this limit (default).
+.TP
 .I umask
 set process umask for the lshell session. Value must be octal (0000 to 0777),
 for example \fB0002\fR.

--- a/man/lshell.1
+++ b/man/lshell.1
@@ -457,6 +457,10 @@ wall-clock timeout in seconds applied per executed command. Commands exceeding
 this timeout are terminated and reported as denied by runtime containment.
 Set to \fB0\fR to disable this limit (default).
 .TP
+.I max_processes
+maximum processes per spawned command via \fBRLIMIT_NPROC\fR.
+Set to \fB0\fR to disable this limit (default).
+.TP
 .I umask
 set process umask for the lshell session. Value must be octal (0000 to 0777),
 for example \fB0002\fR.

--- a/man/lshell.1
+++ b/man/lshell.1
@@ -460,6 +460,8 @@ Set to \fB0\fR to disable this limit (default).
 .I max_processes
 maximum processes per spawned command via \fBRLIMIT_NPROC\fR.
 Set to \fB0\fR to disable this limit (default).
+Best practice: keep \fBcommand_timeout\fR enabled whenever \fBmax_processes\fR
+is strict (especially \fB1\fR).
 .TP
 .I umask
 set process umask for the lshell session. Value must be octal (0000 to 0777),

--- a/man/lshell.1
+++ b/man/lshell.1
@@ -452,6 +452,11 @@ Set to \fB0\fR to disable this limit (default).
 maximum active background jobs (\fB&\fR) allowed in one lshell session.
 Set to \fB0\fR to disable this limit (default).
 .TP
+.I command_timeout
+wall-clock timeout in seconds applied per executed command. Commands exceeding
+this timeout are terminated and reported as denied by runtime containment.
+Set to \fB0\fR to disable this limit (default).
+.TP
 .I umask
 set process umask for the lshell session. Value must be octal (0000 to 0777),
 for example \fB0002\fR.

--- a/man/lshell.1
+++ b/man/lshell.1
@@ -448,6 +448,10 @@ a value in seconds for the session timer
 maximum concurrent lshell sessions for the same user.
 Set to \fB0\fR to disable this limit (default).
 .TP
+.I max_background_jobs
+maximum active background jobs (\fB&\fR) allowed in one lshell session.
+Set to \fB0\fR to disable this limit (default).
+.TP
 .I umask
 set process umask for the lshell session. Value must be octal (0000 to 0777),
 for example \fB0002\fR.

--- a/test/test_audit_functional.py
+++ b/test/test_audit_functional.py
@@ -19,6 +19,21 @@ PROMPT = f"{USER}:~\\$"
 class TestAuditFunctional(unittest.TestCase):
     """Validate ECS audit events from a real interactive shell session."""
 
+    def _load_command_events(self, logfile):
+        events = []
+        with open(logfile, "r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if payload.get("event.action") == "command_authorization":
+                    events.append(payload)
+        return events
+
     def test_security_audit_json_emits_allowed_and_denied_events(self):
         """Emit structured events with success/failure outcomes and reasons."""
         with tempfile.TemporaryDirectory(prefix="lshell-audit-log-") as log_dir:
@@ -45,17 +60,7 @@ class TestAuditFunctional(unittest.TestCase):
             logfile = os.path.join(log_dir, f"{USER}.log")
             self.assertTrue(os.path.exists(logfile))
 
-            with open(logfile, "r", encoding="utf-8") as handle:
-                lines = [line.strip() for line in handle if line.strip()]
-
-            events = []
-            for line in lines:
-                try:
-                    payload = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                if payload.get("event.action") == "command_authorization":
-                    events.append(payload)
+            events = self._load_command_events(logfile)
 
             self.assertGreaterEqual(len(events), 2)
 
@@ -75,6 +80,46 @@ class TestAuditFunctional(unittest.TestCase):
             self.assertTrue(allowed, msg=f"missing allowed audit event in {events}")
             self.assertTrue(denied, msg=f"missing denied audit event in {events}")
             self.assertIn("unknown syntax", denied[0].get("event.reason", ""))
+
+    def test_runtime_limit_denial_reason_is_machine_readable_in_audit(self):
+        """Denied runtime-limit actions should emit machine-readable reason strings."""
+        with tempfile.TemporaryDirectory(prefix="lshell-audit-log-") as log_dir:
+            with tempfile.TemporaryDirectory(prefix="lshell-audit-session-") as session_dir:
+                env = os.environ.copy()
+                env["LSHELL_SESSION_DIR"] = session_dir
+                child = pexpect.spawn(
+                    f"{LSHELL} --config {CONFIG} --log {log_dir} --security_audit_json=1 "
+                    "--loglevel 4 --strict 1 --forbidden \"[]\" --allowed \"['sleep']\" "
+                    "--max_background_jobs 1",
+                    encoding="utf-8",
+                    timeout=10,
+                    env=env,
+                )
+                try:
+                    child.expect(PROMPT)
+                    child.sendline("sleep 60 &")
+                    child.expect(PROMPT)
+                    child.sendline("sleep 60 &")
+                    child.expect(PROMPT)
+                    child.sendline("exit")
+                    child.expect(PROMPT)
+                    child.sendline("exit")
+                    child.expect(pexpect.EOF)
+                finally:
+                    child.close()
+
+            logfile = os.path.join(log_dir, f"{USER}.log")
+            self.assertTrue(os.path.exists(logfile))
+            events = self._load_command_events(logfile)
+
+            denied = [
+                event
+                for event in events
+                if event.get("event.outcome") == "failure"
+                and "runtime_limit.max_background_jobs_exceeded"
+                in event.get("event.reason", "")
+            ]
+            self.assertTrue(denied, msg=f"missing runtime-limit denial in {events}")
 
 
 if __name__ == "__main__":

--- a/test/test_audit_unit.py
+++ b/test/test_audit_unit.py
@@ -102,3 +102,33 @@ class TestAuditLogging(unittest.TestCase):
         }
         audit.log_command_event(conf, "echo ok", allowed=True, reason="allowed")
         self.assertEqual(logger.entries, [])
+
+    def test_log_security_event_keeps_machine_readable_reason(self):
+        """Generic runtime security events should retain reason code strings."""
+        logger = _DummyAuditLogger()
+        conf = {
+            "security_audit_json": 1,
+            "logpath": logger,
+            "session_id": "session-abc",
+            "username": "testuser",
+        }
+
+        audit.log_security_event(
+            conf,
+            action="runtime_containment",
+            allowed=False,
+            reason="runtime_limit.max_background_jobs_exceeded",
+            command="sleep 60 &",
+            level="warning",
+            message="lshell runtime containment decision",
+        )
+
+        self.assertEqual(len(logger.entries), 1)
+        level, message, extra = logger.entries[0]
+        self.assertEqual(level, logging.WARNING)
+        self.assertEqual(message, "lshell runtime containment decision")
+        self.assertEqual(extra["event_action"], "runtime_containment")
+        self.assertEqual(
+            extra["event_reason"], "runtime_limit.max_background_jobs_exceeded"
+        )
+        self.assertEqual(extra["event_outcome"], "failure")

--- a/test/test_containment_functional.py
+++ b/test/test_containment_functional.py
@@ -16,7 +16,7 @@ PROMPT = f"{USER}:~\\$"
 
 
 class TestRuntimeContainmentFunctional(unittest.TestCase):
-    """Validate max_sessions_per_user in a real shell session."""
+    """Validate runtime containment limits in a real shell session."""
 
     def _spawn_shell(self, extra_args, env=None, timeout=15):
         command = f"{LSHELL} --config {CONFIG} {extra_args}"
@@ -62,6 +62,25 @@ class TestRuntimeContainmentFunctional(unittest.TestCase):
                 if second is not None:
                     second.close(force=True)
                 self._safe_exit(first)
+
+    def test_max_background_jobs_enforced(self):
+        """Deny new background command when max_background_jobs is reached."""
+        child = self._spawn_shell(
+            "--strict 1 --forbidden \"[]\" --allowed \"['sleep']\" "
+            "--max_background_jobs 1"
+        )
+        try:
+            child.expect(PROMPT)
+            child.sendline("sleep 60 &")
+            child.expect(PROMPT)
+
+            child.sendline("sleep 60 &")
+            child.expect(PROMPT)
+            output = child.before
+            self.assertIn("background job denied", output)
+            self.assertIn("max_background_jobs=1", output)
+        finally:
+            self._safe_exit(child)
 
 
 if __name__ == "__main__":

--- a/test/test_containment_functional.py
+++ b/test/test_containment_functional.py
@@ -97,6 +97,28 @@ class TestRuntimeContainmentFunctional(unittest.TestCase):
         finally:
             self._safe_exit(child)
 
+    def _last_non_empty_line(self, text):
+        lines = [line.strip() for line in text.splitlines() if line.strip()]
+        return lines[-1] if lines else ""
+
+    def test_max_processes_denies_forking_pipeline(self):
+        """Low max_processes should fail a command requiring child process forks."""
+        child = self._spawn_shell(
+            "--strict 1 --forbidden \"[]\" --allowed \"['cat','echo']\" "
+            "--max_processes 1 --command_timeout 2"
+        )
+        try:
+            child.expect(PROMPT)
+            child.sendline("echo hi | cat")
+            child.expect(PROMPT)
+
+            child.sendline("echo $?")
+            child.expect(PROMPT)
+            exit_line = self._last_non_empty_line(child.before)
+            self.assertNotEqual(exit_line, "0")
+        finally:
+            self._safe_exit(child)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_containment_functional.py
+++ b/test/test_containment_functional.py
@@ -82,6 +82,21 @@ class TestRuntimeContainmentFunctional(unittest.TestCase):
         finally:
             self._safe_exit(child)
 
+    def test_command_timeout_kills_long_running_command(self):
+        """Terminate foreground command when command_timeout is exceeded."""
+        child = self._spawn_shell(
+            "--strict 1 --forbidden \"[]\" --allowed \"['sleep']\" "
+            "--command_timeout 1"
+        )
+        try:
+            child.expect(PROMPT)
+            child.sendline("sleep 3")
+            child.expect(PROMPT)
+            output = child.before
+            self.assertIn("command timed out after 1s", output)
+        finally:
+            self._safe_exit(child)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_containment_functional.py
+++ b/test/test_containment_functional.py
@@ -1,0 +1,68 @@
+"""Functional tests for runtime containment limits."""
+
+import os
+import tempfile
+import unittest
+from getpass import getuser
+
+import pexpect
+
+
+TOPDIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+CONFIG = f"{TOPDIR}/test/testfiles/test.conf"
+LSHELL = f"{TOPDIR}/bin/lshell"
+USER = getuser()
+PROMPT = f"{USER}:~\\$"
+
+
+class TestRuntimeContainmentFunctional(unittest.TestCase):
+    """Validate max_sessions_per_user in a real shell session."""
+
+    def _spawn_shell(self, extra_args, env=None, timeout=15):
+        command = f"{LSHELL} --config {CONFIG} {extra_args}"
+        return pexpect.spawn(command, encoding="utf-8", timeout=timeout, env=env)
+
+    def _env_with(self, **extra):
+        env = os.environ.copy()
+        env.update(extra)
+        return env
+
+    def _safe_exit(self, child):
+        if not child.isalive():
+            return
+        child.sendline("exit")
+        try:
+            child.expect(pexpect.EOF, timeout=3)
+            return
+        except pexpect.TIMEOUT:
+            pass
+
+        if child.isalive():
+            child.sendline("exit")
+            child.expect(pexpect.EOF, timeout=5)
+
+    def test_max_sessions_per_user_enforced(self):
+        """Deny second concurrent shell when max_sessions_per_user is exceeded."""
+        with tempfile.TemporaryDirectory(prefix="lshell-session-func-") as session_dir:
+            env = self._env_with(LSHELL_SESSION_DIR=session_dir)
+            first = self._spawn_shell("--max_sessions_per_user 1 --strict 1", env=env)
+            second = None
+            try:
+                first.expect(PROMPT)
+
+                second = self._spawn_shell(
+                    "--max_sessions_per_user 1 --strict 1",
+                    env=env,
+                )
+                second.expect(pexpect.EOF)
+                output = second.before
+                self.assertIn("session denied", output)
+                self.assertIn("max_sessions_per_user=1", output)
+            finally:
+                if second is not None:
+                    second.close(force=True)
+                self._safe_exit(first)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_containment_unit.py
+++ b/test/test_containment_unit.py
@@ -3,10 +3,12 @@
 import json
 import os
 import tempfile
+import time
 import unittest
 from unittest.mock import patch
 
 from lshell import containment
+from lshell import utils
 from lshell.checkconfig import CheckConfig
 
 
@@ -24,6 +26,7 @@ class TestContainmentConfigValidation(unittest.TestCase):
         conf = CheckConfig(self.base_args).returnconf()
         self.assertEqual(conf["max_sessions_per_user"], 0)
         self.assertEqual(conf["max_background_jobs"], 0)
+        self.assertEqual(conf["command_timeout"], 0)
 
     def test_max_sessions_per_user_rejects_negative_values(self):
         """Runtime containment integer keys must be non-negative."""
@@ -89,6 +92,25 @@ class TestSessionAccounting(unittest.TestCase):
                 accountant.acquire()
                 self.assertFalse(os.path.exists(stale_path))
                 accountant.release()
+
+
+class TestRuntimeExecutionHelpers(unittest.TestCase):
+    """Validate timeout helper behavior."""
+
+    def test_exec_cmd_timeout_returns_124(self):
+        """Foreground commands should be killed when command_timeout is exceeded."""
+        conf = {
+            "command_timeout": 1,
+            "max_sessions_per_user": 0,
+            "max_background_jobs": 0,
+            "security_audit_json": 0,
+        }
+        started = time.monotonic()
+        ret = utils.exec_cmd("sleep 2", conf=conf)
+        elapsed = time.monotonic() - started
+
+        self.assertEqual(ret, 124)
+        self.assertLess(elapsed, 2.5)
 
 
 if __name__ == "__main__":

--- a/test/test_containment_unit.py
+++ b/test/test_containment_unit.py
@@ -112,6 +112,46 @@ class TestRuntimeExecutionHelpers(unittest.TestCase):
         self.assertEqual(ret, 124)
         self.assertLess(elapsed, 2.5)
 
+    def test_apply_rlimits_applies_max_processes(self):
+        """rlimit helper should apply max_processes via RLIMIT_NPROC."""
+
+        class FakeResource:
+            """Minimal resource-module stub capturing setrlimit calls."""
+
+            RLIMIT_NPROC = 1
+
+            def __init__(self):
+                self.calls = []
+
+            def setrlimit(self, key, value):
+                """Record the requested resource limit tuple."""
+                self.calls.append((key, value))
+
+        fake_resource = FakeResource()
+        limits = containment.RuntimeLimits(max_processes=10)
+        unsupported = containment.apply_rlimits(limits, resource_module=fake_resource)
+
+        self.assertEqual(unsupported, [])
+        self.assertIn((FakeResource.RLIMIT_NPROC, (10, 10)), fake_resource.calls)
+
+    def test_apply_rlimits_reports_unsupported_max_processes(self):
+        """Missing RLIMIT_NPROC should be reported, not crash."""
+
+        class MissingResource:
+            """Resource stub without RLIMIT constants for unsupported-path tests."""
+
+            def setrlimit(self, _key, _value):
+                """Fail if called since no RLIMIT constants are exposed."""
+                raise AssertionError("setrlimit should not be called without constants")
+
+        limits = containment.RuntimeLimits(max_processes=1)
+        unsupported = containment.apply_rlimits(
+            limits,
+            resource_module=MissingResource(),
+        )
+
+        self.assertIn("max_processes", unsupported)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_containment_unit.py
+++ b/test/test_containment_unit.py
@@ -20,14 +20,17 @@ class TestContainmentConfigValidation(unittest.TestCase):
     base_args = [f"--config={CONFIG}", "--quiet=1"]
 
     def test_max_sessions_per_user_defaults_disabled(self):
-        """max_sessions_per_user should default to 0."""
+        """Runtime containment keys should default to disabled mode."""
         conf = CheckConfig(self.base_args).returnconf()
         self.assertEqual(conf["max_sessions_per_user"], 0)
+        self.assertEqual(conf["max_background_jobs"], 0)
 
     def test_max_sessions_per_user_rejects_negative_values(self):
-        """max_sessions_per_user must be non-negative."""
-        with self.assertRaises(SystemExit):
-            CheckConfig(self.base_args + ["--max_sessions_per_user=-1"]).returnconf()
+        """Runtime containment integer keys must be non-negative."""
+        for key in containment.RUNTIME_LIMIT_INT_KEYS:
+            with self.subTest(key=key):
+                with self.assertRaises(SystemExit):
+                    CheckConfig(self.base_args + [f"--{key}=-1"]).returnconf()
 
 
 class TestSessionAccounting(unittest.TestCase):

--- a/test/test_containment_unit.py
+++ b/test/test_containment_unit.py
@@ -1,0 +1,92 @@
+"""Unit tests for runtime containment helpers."""
+
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from lshell import containment
+from lshell.checkconfig import CheckConfig
+
+
+TOPDIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+CONFIG = f"{TOPDIR}/test/testfiles/test.conf"
+
+
+class TestContainmentConfigValidation(unittest.TestCase):
+    """Validate max_sessions_per_user parsing and bounds."""
+
+    base_args = [f"--config={CONFIG}", "--quiet=1"]
+
+    def test_max_sessions_per_user_defaults_disabled(self):
+        """max_sessions_per_user should default to 0."""
+        conf = CheckConfig(self.base_args).returnconf()
+        self.assertEqual(conf["max_sessions_per_user"], 0)
+
+    def test_max_sessions_per_user_rejects_negative_values(self):
+        """max_sessions_per_user must be non-negative."""
+        with self.assertRaises(SystemExit):
+            CheckConfig(self.base_args + ["--max_sessions_per_user=-1"]).returnconf()
+
+
+class TestSessionAccounting(unittest.TestCase):
+    """Exercise session accounting limits and stale cleanup."""
+
+    def _session_conf(self, session_id):
+        return {
+            "username": "testuser",
+            "session_id": session_id,
+            "max_sessions_per_user": 1,
+        }
+
+    def test_session_accounting_enforces_cap(self):
+        """Second session should be denied when cap is reached."""
+        with tempfile.TemporaryDirectory(prefix="lshell-session-unit-") as session_dir:
+            with patch.dict(
+                os.environ,
+                {"LSHELL_SESSION_DIR": session_dir},
+                clear=False,
+            ):
+                first = containment.SessionAccountant(self._session_conf("one"))
+                first.acquire()
+
+                second = containment.SessionAccountant(self._session_conf("two"))
+                with self.assertRaises(containment.ContainmentViolation) as violation:
+                    second.acquire()
+
+                self.assertIn(
+                    "runtime_limit.max_sessions_per_user_exceeded",
+                    violation.exception.reason_code,
+                )
+                first.release()
+
+    def test_session_accounting_cleans_stale_entries(self):
+        """Dead PID records should be removed before counting active sessions."""
+        with tempfile.TemporaryDirectory(prefix="lshell-session-unit-") as session_dir:
+            with patch.dict(
+                os.environ,
+                {"LSHELL_SESSION_DIR": session_dir},
+                clear=False,
+            ):
+                accountant = containment.SessionAccountant(self._session_conf("active"))
+                os.makedirs(accountant.user_dir, exist_ok=True)
+                stale_path = os.path.join(accountant.user_dir, "session-stale.json")
+                with open(stale_path, "w", encoding="utf-8") as handle:
+                    json.dump(
+                        {
+                            "pid": 999999,
+                            "pid_start": "1",
+                            "session_id": "stale",
+                            "username": "testuser",
+                        },
+                        handle,
+                    )
+
+                accountant.acquire()
+                self.assertFalse(os.path.exists(stale_path))
+                accountant.release()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_extension_parser_unit.py
+++ b/test/test_extension_parser_unit.py
@@ -3,7 +3,7 @@
 import io
 import os
 import unittest
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 from lshell import sec
 from lshell import utils
@@ -105,7 +105,11 @@ class TestExtensionParser(unittest.TestCase):
         shell_context = DummyShellContext(conf)
         retcode = utils.cmd_parse_execute("ls /tmp", shell_context=shell_context)
         self.assertEqual(retcode, 0)
-        mock_exec_cmd.assert_called_once_with("ls /tmp")
+        mock_exec_cmd.assert_called_once_with(
+            "ls /tmp",
+            conf=ANY,
+            log=ANY,
+        )
 
 
 if __name__ == "__main__":

--- a/test/test_policy.py
+++ b/test/test_policy.py
@@ -1,9 +1,11 @@
 """Unit tests for lshell policy diagnostics mode."""
 
+import io
 import os
 import tempfile
 import textwrap
 import unittest
+from contextlib import redirect_stdout
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -422,6 +424,64 @@ class TestPolicy(unittest.TestCase):
         )
         self.assertEqual(retcode, 0)
         self.assertEqual(ctx.called, "echo hi")
+
+    def test_print_user_view_includes_containment_settings(self):
+        """EX11 | policy overview includes runtime containment limits."""
+        result = {
+            "policy": {
+                "username": "bleh",
+                "strict": 1,
+                "warning_counter": 2,
+                "allowed": ["ls"],
+                "aliases": {},
+                "sudo_commands": [],
+                "timer": 0,
+                "forbidden": [";"],
+                "allowed_file_extensions": [],
+                "max_sessions_per_user": 2,
+                "max_background_jobs": 3,
+                "command_timeout": 15,
+                "max_processes": 10,
+            }
+        }
+
+        with redirect_stdout(io.StringIO()) as output:
+            policy.print_user_view(result)
+        rendered = output.getvalue()
+
+        self.assertIn("Max sessions/user      : 2", rendered)
+        self.assertIn("Max background jobs    : 3", rendered)
+        self.assertIn("Command timeout (sec)  : 15s", rendered)
+        self.assertIn("Max processes          : 10", rendered)
+
+    def test_print_user_view_shows_unlimited_for_zero_containment_limits(self):
+        """EX12 | zero-valued containment limits should render as Unlimited."""
+        result = {
+            "policy": {
+                "username": "bleh",
+                "strict": 0,
+                "warning_counter": 2,
+                "allowed": ["ls"],
+                "aliases": {},
+                "sudo_commands": [],
+                "timer": 0,
+                "forbidden": [";"],
+                "allowed_file_extensions": [],
+                "max_sessions_per_user": 0,
+                "max_background_jobs": 0,
+                "command_timeout": 0,
+                "max_processes": 0,
+            }
+        }
+
+        with redirect_stdout(io.StringIO()) as output:
+            policy.print_user_view(result)
+        rendered = output.getvalue()
+
+        self.assertIn("Max sessions/user      : Unlimited", rendered)
+        self.assertIn("Max background jobs    : Unlimited", rendered)
+        self.assertIn("Command timeout (sec)  : Unlimited", rendered)
+        self.assertIn("Max processes          : Unlimited", rendered)
 
 
 if __name__ == "__main__":

--- a/test/test_security_attack_surface_unit.py
+++ b/test/test_security_attack_surface_unit.py
@@ -367,7 +367,7 @@ class TestAttackSurface(unittest.TestCase):
         mock_secure.side_effect = lambda line, conf, strict=None: (0, conf)
         mock_path.side_effect = lambda line, conf, strict=None: (0, conf)
 
-        def exec_side_effect(command, background=False, extra_env=None):
+        def exec_side_effect(command, background=False, extra_env=None, **_kwargs):
             if command == "false":
                 return 1
             if command == "echo recovered":

--- a/test/test_security_attack_surface_unit_part2.py
+++ b/test/test_security_attack_surface_unit_part2.py
@@ -459,6 +459,8 @@ class TestAttackSurfacePart2(unittest.TestCase):
             "/usr/libexec/sftp-server",
             background=False,
             extra_env=unittest.mock.ANY,
+            conf=unittest.mock.ANY,
+            log=unittest.mock.ANY,
         )
 
     @patch("lshell.utils.exec_cmd", side_effect=[1, 0])

--- a/test/test_shellcmd_signal_unit.py
+++ b/test/test_shellcmd_signal_unit.py
@@ -1,0 +1,70 @@
+"""Unit tests for shell signal-related control flow in ShellCmd."""
+
+import io
+import os
+import unittest
+from unittest.mock import patch
+
+from lshell.checkconfig import CheckConfig
+from lshell.shellcmd import ShellCmd
+
+TOPDIR = f"{os.path.dirname(os.path.realpath(__file__))}/../"
+CONFIG = f"{TOPDIR}/test/testfiles/test.conf"
+
+
+class TestShellCmdSignalUnit(unittest.TestCase):
+    """Validate ShellCmd behavior for Ctrl+C and Ctrl+D/EOF flows."""
+
+    args = [f"--config={CONFIG}", "--quiet=1"]
+
+    def _make_shell(self):
+        conf = CheckConfig(self.args + ["--strict=0"]).returnconf()
+        shell = ShellCmd(
+            conf,
+            args=[],
+            stdin=io.StringIO(),
+            stdout=io.StringIO(),
+            stderr=io.StringIO(),
+        )
+        shell.use_rawinput = False
+        return shell
+
+    def test_cmdloop_recovers_from_keyboard_interrupt_during_job_check(self):
+        """Keep cmdloop alive when Ctrl+C races outside input() handling."""
+        shell = self._make_shell()
+        shell.cmdqueue = ["exit"]
+
+        with patch(
+            "lshell.shellcmd.builtincmd.check_background_jobs",
+            side_effect=[KeyboardInterrupt, None],
+        ) as mock_jobs:
+            with patch(
+                "lshell.shellcmd.utils.updateprompt",
+                return_value="unit-prompt$ ",
+            ) as mock_prompt:
+                with patch("lshell.shellcmd.readline.write_history_file"):
+                    with patch("lshell.shellcmd.sys.exit", side_effect=SystemExit):
+                        with self.assertRaises(SystemExit):
+                            shell.cmdloop()
+
+        self.assertGreaterEqual(mock_jobs.call_count, 2)
+        mock_prompt.assert_called_once_with(os.getcwd(), shell.conf)
+        self.assertEqual(shell.conf["promptprint"], "unit-prompt$ ")
+
+    def test_do_eof_delegates_to_exit(self):
+        """Route EOF (Ctrl+D) through unified exit behavior."""
+        shell = self._make_shell()
+        with patch.object(shell, "do_exit", return_value=123) as mock_exit:
+            self.assertEqual(shell.do_EOF(), 123)
+        mock_exit.assert_called_once_with(None)
+
+    def test_do_quit_delegates_to_exit(self):
+        """Route quit through unified exit behavior."""
+        shell = self._make_shell()
+        with patch.object(shell, "do_exit", return_value=456) as mock_exit:
+            self.assertEqual(shell.do_quit(), 456)
+        mock_exit.assert_called_once_with(None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_signals.py
+++ b/test/test_signals.py
@@ -314,3 +314,25 @@ class TestFunctions(unittest.TestCase):
         assert (
             output == expected_output
         ), f"Expected '{expected_output}', got '{output}'"
+
+    def test_78_ctrl_d_with_stopped_jobs_no_unknown_syntax(self):
+        """F78 | Ctrl+D with stopped jobs should warn without unknown EOF syntax."""
+        child = pexpect.spawn(f"{LSHELL} --config {CONFIG} --allowed \"+['tail']\"")
+        child.expect(PROMPT)
+
+        child.sendline("tail -f")
+        time.sleep(1)
+        child.sendcontrol("z")
+        child.expect(r"\[\d+\]\+  Stopped        tail -f", timeout=1)
+        child.expect(PROMPT)
+
+        # First Ctrl+D should warn and keep shell alive.
+        child.sendeof()
+        child.expect("There are stopped jobs.", timeout=5)
+        child.expect(PROMPT, timeout=5)
+        output = child.before.decode("utf-8")
+        assert "unknown syntax: EOF" not in output, output
+
+        # Second Ctrl+D should exit (kill remaining stopped jobs).
+        child.sendeof()
+        child.expect(pexpect.EOF, timeout=5)

--- a/test/test_signals.py
+++ b/test/test_signals.py
@@ -253,7 +253,12 @@ class TestFunctions(unittest.TestCase):
 
         # Interrupt the foreground process (should not affect background)
         child.sendcontrol("c")
-        child.expect(PROMPT)
+        try:
+            child.expect(PROMPT, timeout=5)
+        except pexpect.TIMEOUT:
+            # Some PTY/readline combinations only redraw on next Enter.
+            child.sendline("")
+            child.expect(PROMPT, timeout=5)
 
         # Verify the background command is still running
         child.sendline("jobs")


### PR DESCRIPTION
## Summary
This PR introduces runtime containment controls in lshell and wires them into command/session execution paths.

## What’s included
- `max_sessions_per_user`: enforce per-user concurrent session caps.
- `max_background_jobs`: enforce active `&` job limits.
- `command_timeout`: enforce per-command wall-clock timeout.
- `max_processes`: apply `RLIMIT_NPROC` to spawned commands.

## Additional changes
- Config/schema/docs updated (`etc/lshell.conf`, README, man page, changelog).
- Audit/config handling updated to report denial/warning reasons clearly.
- New containment unit + functional tests, plus related audit/security test updates.
