### PR TITLE
Fix LPS1 prompt timezone rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ test.lsh
 .pylint_cache/
 .pylint.d/
 .hypothesis/
+.venv/
+local-docs/
+.vscode/
+.idea/

--- a/lshell/utils.py
+++ b/lshell/utils.py
@@ -12,7 +12,7 @@ import shlex
 import shutil
 import threading
 from getpass import getuser
-from time import strftime, gmtime
+from time import strftime, localtime
 import signal
 
 # import lshell specifics
@@ -806,6 +806,7 @@ def parse_ps1(ps1):
     cwd = os.getcwd()
     home = os.path.expanduser("~")
     prompt_symbol = "#" if os.geteuid() == 0 else "$"
+    current_time = localtime()
 
     # Define LPS1 replacement mappings
     replacements = {
@@ -816,11 +817,11 @@ def parse_ps1(ps1):
         r"\W": os.path.basename(cwd),
         r"\$": prompt_symbol,
         r"\\": "\\",
-        r"\t": strftime("%H:%M:%S", gmtime()),
-        r"\T": strftime("%I:%M:%S", gmtime()),
-        r"\A": strftime("%H:%M", gmtime()),
-        r"\@": strftime("%I:%M:%S%p", gmtime()),
-        r"\d": strftime("%a %b %d", gmtime()),
+        r"\t": strftime("%H:%M:%S", current_time),
+        r"\T": strftime("%I:%M:%S", current_time),
+        r"\A": strftime("%H:%M", current_time),
+        r"\@": strftime("%I:%M:%S%p", current_time),
+        r"\d": strftime("%a %b %d", current_time),
     }
     # Replace each placeholder with its corresponding value
     for placeholder, value in replacements.items():

--- a/test/test_prompt_unit.py
+++ b/test/test_prompt_unit.py
@@ -3,10 +3,11 @@
 import os
 import unittest
 from getpass import getuser
+from time import struct_time
 from unittest.mock import patch
 
 from lshell.config.runtime import CheckConfig
-from lshell.utils import getpromptbase, updateprompt
+from lshell.utils import getpromptbase, parse_ps1, updateprompt
 
 TOPDIR = f"{os.path.dirname(os.path.realpath(__file__))}/../"
 CONFIG = f"{TOPDIR}/test/testfiles/test.conf"
@@ -39,6 +40,14 @@ class TestPromptUnit(unittest.TestCase):
             rendered = getpromptbase(conf)
         expected = f"{getuser()}@{os.uname()[1].split('.')[0]}"
         self.assertEqual(rendered, expected)
+
+    def test_parse_ps1_time_placeholders_use_localtime(self):
+        """LPS1 time placeholders should render in local server time."""
+        fixed_localtime = struct_time((2026, 6, 16, 21, 7, 5, 1, 167, -1))
+        with patch("lshell.utils.localtime", return_value=fixed_localtime) as mock_localtime:
+            rendered = parse_ps1(r"\t|\T|\A")
+        self.assertEqual(rendered, "21:07:05|09:07:05|21:07")
+        mock_localtime.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -7,7 +7,7 @@ import sys
 import tempfile
 import unittest
 from getpass import getuser
-from time import strftime, gmtime
+from time import strftime, localtime
 from unittest.mock import patch
 
 # import lshell specifics
@@ -317,7 +317,10 @@ class TestFunctions(unittest.TestCase):
     def test_lps1_user_host_time(self):
         r"""U32 | LPS1 using \u@\h - \t> format"""
         os.environ["LPS1"] = r"\u@\h - \t> "
-        expected = f"{getuser()}@{os.uname()[1].split('.')[0]} - {strftime('%H:%M:%S', gmtime())}> "
+        expected = (
+            f"{getuser()}@{os.uname()[1].split('.')[0]} - "
+            f"{strftime('%H:%M:%S', localtime())}> "
+        )
         prompt = parse_ps1(os.getenv("LPS1"))
         self.assertEqual(prompt, expected)
         del os.environ["LPS1"]


### PR DESCRIPTION
## Summary
- render LPS1 time placeholders using local server time instead of UTC
- add prompt tests covering localtime rendering
- keep local workspace ignore entries used in the fork