### PR TITLE
Hotfix/path acl symlink guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ test.lsh
 .pylint_cache/
 .pylint.d/
 .hypothesis/
+.venv/
+local-docs/
+.vscode/
+.idea/

--- a/lshell/sec.py
+++ b/lshell/sec.py
@@ -27,6 +27,46 @@ inspect_shell_expansions = expansion_inspector.inspect_shell_expansions
 
 _EXTGLOB_OPENERS = ("@(", "!(", "+(", "*(", "?(")
 
+# Commands whose positional operands commonly refer to filesystem entries.
+# We use this to protect bareword symlink targets without treating generic
+# literals (for example `echo hello`) as path operands.
+_BAREWORD_FILESYSTEM_COMMANDS = {
+    "cat",
+    "chgrp",
+    "chmod",
+    "chown",
+    "cmp",
+    "comm",
+    "cp",
+    "diff",
+    "du",
+    "file",
+    "grep",
+    "egrep",
+    "fgrep",
+    "rgrep",
+    "head",
+    "install",
+    "less",
+    "ln",
+    "ls",
+    "mkdir",
+    "more",
+    "mv",
+    "nl",
+    "patch",
+    "readlink",
+    "realpath",
+    "rm",
+    "rmdir",
+    "stat",
+    "tac",
+    "tail",
+    "tee",
+    "touch",
+    "wc",
+}
+
 
 def _is_assignment_word(word):
     return bool(re.match(r"^[A-Za-z_][A-Za-z0-9_]*=.*$", word))
@@ -184,6 +224,14 @@ def _safe_expand_path(path):
         return os.path.expandvars(expanded)
     except (TypeError, ValueError):
         return None
+
+
+def _safe_lexists(path):
+    """Return os.path.lexists(path) while rejecting malformed inputs."""
+    try:
+        return os.path.lexists(path)
+    except (OSError, TypeError, ValueError):
+        return False
 
 
 def _contains_unescaped_extglob(pattern):
@@ -456,6 +504,39 @@ def _looks_like_path_token(token):
     return False
 
 
+def _looks_like_numeric_literal(token):
+    """Return True for plain numeric arguments such as `10` or `-1`."""
+    return bool(re.fullmatch(r"[-+]?\d+(?:\.\d+)?", token))
+
+
+def _references_existing_path(token):
+    """Return True when token resolves to an existing filesystem entry."""
+    expanded = _safe_expand_path(token)
+    if expanded is None:
+        return False
+    if not os.path.isabs(expanded):
+        expanded = os.path.join(os.getcwd(), expanded)
+    return _safe_lexists(expanded)
+
+
+def _command_name(command):
+    """Return a basename-style command identifier for operand heuristics."""
+    if not command:
+        return ""
+    return os.path.basename(command)
+
+
+def _should_check_bareword_path_operand(command, token):
+    """Return True when a bareword operand should be treated as a path."""
+    if not token or token == "-" or token.startswith("-"):
+        return False
+    if _looks_like_numeric_literal(token):
+        return False
+    if _command_name(command) not in _BAREWORD_FILESYSTEM_COMMANDS:
+        return False
+    return _references_existing_path(token)
+
+
 def _grep_implicit_pattern_index(args):
     """Return the grep implicit PATTERN arg index, or None when explicit patterns are used."""
     has_explicit_pattern = False
@@ -535,7 +616,11 @@ def _path_tokens_from_line(line):
             path_tokens.extend(
                 token
                 for idx, token in enumerate(args)
-                if idx not in skip_indices and _looks_like_path_token(token)
+                if idx not in skip_indices
+                and (
+                    _looks_like_path_token(token)
+                    or _should_check_bareword_path_operand(command, token)
+                )
             )
             continue
 

--- a/lshell/sec.py
+++ b/lshell/sec.py
@@ -26,11 +26,14 @@ _scan_shell_expansions = expansion_inspector._scan_shell_expansions
 inspect_shell_expansions = expansion_inspector.inspect_shell_expansions
 
 _EXTGLOB_OPENERS = ("@(", "!(", "+(", "*(", "?(")
+_AWK_COMMANDS = {"awk", "gawk", "mawk", "nawk"}
+_SED_COMMANDS = {"sed", "gsed"}
 
 # Commands whose positional operands commonly refer to filesystem entries.
 # We use this to protect bareword symlink targets without treating generic
 # literals (for example `echo hello`) as path operands.
 _BAREWORD_FILESYSTEM_COMMANDS = {
+    *_AWK_COMMANDS,
     "cat",
     "chgrp",
     "chmod",
@@ -59,6 +62,8 @@ _BAREWORD_FILESYSTEM_COMMANDS = {
     "realpath",
     "rm",
     "rmdir",
+    *_SED_COMMANDS,
+    "sort",
     "stat",
     "tac",
     "tail",
@@ -577,6 +582,170 @@ def _grep_implicit_pattern_index(args):
     return None
 
 
+def _awk_non_path_indices(args):
+    """Return awk argument indices that are program/options, not file operands."""
+    skip_indices = set()
+    has_program = False
+    index = 0
+
+    while index < len(args):
+        token = args[index]
+
+        if token == "--":
+            if not has_program and index + 1 < len(args):
+                skip_indices.add(index + 1)
+                has_program = True
+                index += 2
+                continue
+            index += 1
+            continue
+
+        if token in {"-v", "-F"}:
+            if index + 1 < len(args):
+                skip_indices.add(index + 1)
+            index += 2
+            continue
+
+        if token == "-f":
+            # The following argument is an awk program file and must be checked.
+            has_program = True
+            index += 2
+            continue
+
+        if token.startswith(("-v", "-F", "-f", "--")) and token != "-":
+            if token.startswith("-f"):
+                has_program = True
+            index += 1
+            continue
+
+        if token.startswith("-") and token != "-":
+            index += 1
+            continue
+
+        if not has_program:
+            skip_indices.add(index)
+            has_program = True
+
+        index += 1
+
+    return skip_indices
+
+
+def _awk_path_like_non_path_indices(args):
+    """Return awk argument indices that should not be path-checked even if path-like."""
+    skip_indices = set()
+    index = 0
+
+    while index < len(args):
+        token = args[index]
+
+        if token == "--":
+            index += 1
+            continue
+
+        if token in {"-v", "-F"}:
+            if index + 1 < len(args):
+                skip_indices.add(index + 1)
+            index += 2
+            continue
+
+        if token in {"-f"}:
+            index += 2
+            continue
+
+        if token.startswith(("-v", "-F", "--")) and token != "-":
+            index += 1
+            continue
+
+        if token.startswith("-") and token != "-":
+            index += 1
+            continue
+
+        index += 1
+
+    return skip_indices
+
+
+def _sed_non_path_indices(args):
+    """Return sed argument indices that are scripts/options, not file operands."""
+    skip_indices = set()
+    has_script = False
+    index = 0
+
+    while index < len(args):
+        token = args[index]
+
+        if token == "--":
+            if not has_script and index + 1 < len(args):
+                skip_indices.add(index + 1)
+                has_script = True
+                index += 2
+                continue
+            index += 1
+            continue
+
+        if token in {"-e", "--expression"}:
+            if index + 1 < len(args):
+                skip_indices.add(index + 1)
+            has_script = True
+            index += 2
+            continue
+
+        if token in {"-f", "--file"}:
+            # The following argument is a sed script file and must be checked.
+            has_script = True
+            index += 2
+            continue
+
+        if token.startswith(("-e", "--expression=")) and token != "-":
+            has_script = True
+            index += 1
+            continue
+
+        if token.startswith(("-f", "--file=")) and token != "-":
+            has_script = True
+            index += 1
+            continue
+
+        if token.startswith("-") and token != "-":
+            index += 1
+            continue
+
+        if not has_script:
+            skip_indices.add(index)
+            has_script = True
+
+        index += 1
+
+    return skip_indices
+
+
+def _non_path_operand_indices(command, args):
+    """Return argument indices that are not bareword filesystem operands."""
+    command_name = _command_name(command)
+    if command_name in {"grep", "egrep", "fgrep", "rgrep"}:
+        implicit_pattern_index = _grep_implicit_pattern_index(args)
+        return {implicit_pattern_index} if implicit_pattern_index is not None else set()
+    if command_name in _AWK_COMMANDS:
+        return _awk_non_path_indices(args)
+    if command_name in _SED_COMMANDS:
+        return _sed_non_path_indices(args)
+    return set()
+
+
+def _path_like_non_path_operand_indices(command, args):
+    """Return argument indices that should not be path-checked even if path-like."""
+    command_name = _command_name(command)
+    if command_name in {"grep", "egrep", "fgrep", "rgrep"}:
+        implicit_pattern_index = _grep_implicit_pattern_index(args)
+        return {implicit_pattern_index} if implicit_pattern_index is not None else set()
+    if command_name in _AWK_COMMANDS:
+        return _awk_path_like_non_path_indices(args)
+    if command_name in _SED_COMMANDS:
+        return _sed_non_path_indices(args)
+    return set()
+
+
 def _path_tokens_from_line(line):
     """Extract path-like tokens from command segments, excluding bare command names."""
     segments = utils.split_commands(line)
@@ -607,19 +776,21 @@ def _path_tokens_from_line(line):
             continue
 
         if args:
-            skip_indices = set()
-            if command in {"grep", "egrep", "fgrep", "rgrep"}:
-                implicit_pattern_index = _grep_implicit_pattern_index(args)
-                if implicit_pattern_index is not None:
-                    skip_indices.add(implicit_pattern_index)
+            bareword_skip_indices = _non_path_operand_indices(command, args)
+            path_like_skip_indices = _path_like_non_path_operand_indices(command, args)
 
             path_tokens.extend(
                 token
                 for idx, token in enumerate(args)
-                if idx not in skip_indices
-                and (
-                    _looks_like_path_token(token)
-                    or _should_check_bareword_path_operand(command, token)
+                if (
+                    (
+                        idx not in path_like_skip_indices
+                        and _looks_like_path_token(token)
+                    )
+                    or (
+                        idx not in bareword_skip_indices
+                        and _should_check_bareword_path_operand(command, token)
+                    )
                 )
             )
             continue

--- a/test/test_engine_security_regressions_unit.py
+++ b/test/test_engine_security_regressions_unit.py
@@ -1,6 +1,7 @@
 """Security regression coverage for the canonical engine."""
 
 import os
+import tempfile
 import unittest
 
 from lshell.config.runtime import CheckConfig
@@ -105,6 +106,31 @@ class TestEngineSecurityRegressions(unittest.TestCase):
         self.assertTrue(allowed_decision.allowed)
         self.assertFalse(denied_decision.allowed)
         self.assertEqual(denied_decision.reason.code, reasons.FORBIDDEN_PATH)
+
+    def test_authorizer_blocks_bareword_symlink_operand_for_cat(self):
+        """Canonical authorizer must deny bareword symlinks escaping allowed roots."""
+        previous_cwd = os.getcwd()
+        try:
+            with tempfile.TemporaryDirectory(prefix="lshell-engine-symlink-", dir="/tmp") as tmpdir:
+                link_path = os.path.join(tmpdir, "passwdlink")
+                os.symlink("/etc/passwd", link_path)
+                os.chdir(tmpdir)
+
+                decision = authorizer.authorize_line(
+                    "cat passwdlink",
+                    self._policy(
+                        allowed=["cat"],
+                        strict=1,
+                        path=[f"{tmpdir}|", ""],
+                    ),
+                    mode="policy",
+                    check_current_dir=False,
+                )
+
+                self.assertFalse(decision.allowed)
+                self.assertEqual(decision.reason.code, reasons.FORBIDDEN_PATH)
+        finally:
+            os.chdir(previous_cwd)
 
     def test_runtime_blocks_forbidden_env_assignment(self):
         """Runtime should keep forbidden env-assignment protection."""

--- a/test/test_engine_security_regressions_unit.py
+++ b/test/test_engine_security_regressions_unit.py
@@ -132,6 +132,39 @@ class TestEngineSecurityRegressions(unittest.TestCase):
         finally:
             os.chdir(previous_cwd)
 
+    def test_authorizer_blocks_bareword_symlink_operand_for_text_filters(self):
+        """Canonical authorizer must deny filter file operands escaping allowed roots."""
+        previous_cwd = os.getcwd()
+        try:
+            with tempfile.TemporaryDirectory(prefix="lshell-engine-filter-", dir="/tmp") as tmpdir:
+                link_path = os.path.join(tmpdir, "passwdlink")
+                os.symlink("/etc/passwd", link_path)
+                os.chdir(tmpdir)
+
+                for command in (
+                    "awk 1 passwdlink",
+                    "awk -f passwdlink",
+                    "sed -n 1p passwdlink",
+                    "sed -f passwdlink",
+                    "sort passwdlink",
+                ):
+                    with self.subTest(command=command):
+                        decision = authorizer.authorize_line(
+                            command,
+                            self._policy(
+                                allowed=["awk", "sed", "sort"],
+                                strict=1,
+                                path=[f"{tmpdir}|", ""],
+                            ),
+                            mode="policy",
+                            check_current_dir=False,
+                        )
+
+                        self.assertFalse(decision.allowed)
+                        self.assertEqual(decision.reason.code, reasons.FORBIDDEN_PATH)
+        finally:
+            os.chdir(previous_cwd)
+
     def test_runtime_blocks_forbidden_env_assignment(self):
         """Runtime should keep forbidden env-assignment protection."""
         conf = CheckConfig(self.args + ["--forbidden=[]", "--strict=0"]).returnconf()

--- a/test/test_security_attack_surface_unit_part2.py
+++ b/test/test_security_attack_surface_unit_part2.py
@@ -834,6 +834,42 @@ class TestAttackSurfacePart2(unittest.TestCase):
             )
             self.assertEqual(ret, 0)
 
+    def test_check_path_blocks_bareword_symlink_operand_for_file_command(self):
+        """Bareword symlinks must be canonicalized and validated for file commands."""
+        previous_cwd = os.getcwd()
+        try:
+            with tempfile.TemporaryDirectory(prefix="lshell-symlink-deny-", dir="/tmp") as tmpdir:
+                link_path = os.path.join(tmpdir, "passwdlink")
+                os.symlink("/etc/passwd", link_path)
+
+                conf = CheckConfig(
+                    self.args + [f"--path=['{tmpdir}']", "--strict=0"]
+                ).returnconf()
+                os.chdir(tmpdir)
+
+                ret, _conf = sec.check_path("cat passwdlink", conf, strict=0)
+                self.assertEqual(ret, 1)
+        finally:
+            os.chdir(previous_cwd)
+
+    def test_check_path_keeps_non_file_command_bareword_symlink_usable(self):
+        """Non-filesystem commands should not treat generic barewords as path operands."""
+        previous_cwd = os.getcwd()
+        try:
+            with tempfile.TemporaryDirectory(prefix="lshell-symlink-echo-", dir="/tmp") as tmpdir:
+                link_path = os.path.join(tmpdir, "passwdlink")
+                os.symlink("/etc/passwd", link_path)
+
+                conf = CheckConfig(
+                    self.args + [f"--path=['{tmpdir}']", "--strict=0"]
+                ).returnconf()
+                os.chdir(tmpdir)
+
+                ret, _conf = sec.check_path("echo passwdlink", conf, strict=0)
+                self.assertEqual(ret, 0)
+        finally:
+            os.chdir(previous_cwd)
+
     def test_check_path_rejects_nul_byte_path_without_crashing(self):
         """Malformed NUL-byte path operands should fail closed without exceptions."""
         conf = CheckConfig(

--- a/test/test_security_attack_surface_unit_part2.py
+++ b/test/test_security_attack_surface_unit_part2.py
@@ -852,6 +852,56 @@ class TestAttackSurfacePart2(unittest.TestCase):
         finally:
             os.chdir(previous_cwd)
 
+    def test_check_path_blocks_bareword_symlink_operand_for_text_filters(self):
+        """awk/sed/sort file operands must not bypass path ACL as barewords."""
+        previous_cwd = os.getcwd()
+        try:
+            with tempfile.TemporaryDirectory(prefix="lshell-filter-symlink-", dir="/tmp") as tmpdir:
+                link_path = os.path.join(tmpdir, "passwdlink")
+                os.symlink("/etc/passwd", link_path)
+
+                os.chdir(tmpdir)
+
+                for command in (
+                    "awk 1 passwdlink",
+                    "awk -f passwdlink",
+                    "sed -n 1p passwdlink",
+                    "sed -e 1p passwdlink",
+                    "sed -f passwdlink",
+                    "sort passwdlink",
+                ):
+                    with self.subTest(command=command):
+                        conf = CheckConfig(
+                            self.args + [f"--path=['{tmpdir}']", "--strict=0"]
+                        ).returnconf()
+                        os.chdir(tmpdir)
+                        ret, _conf = sec.check_path(command, conf, strict=0)
+                        self.assertEqual(ret, 1)
+        finally:
+            os.chdir(previous_cwd)
+
+    def test_check_path_keeps_awk_and_sed_scripts_from_being_treated_as_files(self):
+        """awk/sed inline scripts are syntax operands; following files are paths."""
+        previous_cwd = os.getcwd()
+        try:
+            with tempfile.TemporaryDirectory(prefix="lshell-filter-script-", dir="/tmp") as tmpdir:
+                awk_script_name = "passwdlink"
+                sed_script_name = "sedscript"
+                for name in (awk_script_name, sed_script_name):
+                    os.symlink("/etc/passwd", os.path.join(tmpdir, name))
+
+                conf = CheckConfig(
+                    self.args + [f"--path=['{tmpdir}']", "--strict=0"]
+                ).returnconf()
+                os.chdir(tmpdir)
+
+                for command in (f"awk {awk_script_name}", f"sed {sed_script_name}"):
+                    with self.subTest(command=command):
+                        ret, _conf = sec.check_path(command, conf, strict=0)
+                        self.assertEqual(ret, 0)
+        finally:
+            os.chdir(previous_cwd)
+
     def test_check_path_keeps_non_file_command_bareword_symlink_usable(self):
         """Non-filesystem commands should not treat generic barewords as path operands."""
         previous_cwd = os.getcwd()

--- a/test/test_security_hardening_functional.py
+++ b/test/test_security_hardening_functional.py
@@ -190,3 +190,21 @@ class TestSecurityHardeningFunctional(unittest.TestCase):
 
             combined = result.stdout + result.stderr
             self.assertIn(f'lshell: forbidden path: "{sibling_dir}/"', combined)
+
+    def test_path_acl_blocks_bareword_symlink_escape_for_cat(self):
+        """Bareword symlink operands should be denied after canonical path resolution."""
+        with tempfile.TemporaryDirectory(prefix="lshell-path-symlink-hardening-", dir="/tmp") as tmpdir:
+            link_path = os.path.join(tmpdir, "passwdlink")
+            os.symlink("/etc/passwd", link_path)
+
+            result = self._run_lsh_script(
+                script_body=f"cd {tmpdir}\ncat passwdlink\necho SAFE\n",
+                extra_shell_args=(
+                    f"--allowed \"+['cat']\" --path \"['{tmpdir}']\" --strict 0"
+                ),
+            )
+
+            combined = result.stdout + result.stderr
+            self.assertIn('lshell: forbidden path: "/etc/passwd"', combined)
+            self.assertIn("SAFE", combined)
+            self.assertNotIn("root:x:0:0:", combined)


### PR DESCRIPTION
# PR Description: Hotfix for bareword symlink path ACL bypass

## Goal

This hotfix fixes a path access control bypass in `lshell` where a restricted user could access a forbidden file through a symlink with a plain bareword name such as `passwdlink`.

The goal of this change is narrow and security-focused:

1. close the verified breakout path
2. keep normal command behavior intact
3. avoid turning ordinary non-filesystem arguments into false-positive path violations

## Short summary

Before this change, path enforcement mostly depended on whether a command argument "looked like a path". That worked for values such as `/etc/passwd`, `./file`, `../file`, `~/file`, or wildcard patterns, but it missed existing filesystem entries referenced only by a simple bareword name.

Because of that, a user inside an allowed directory could create or use a symlink such as:

```text
passwdlink -> /etc/passwd
```

and then run:

```bash
cat passwdlink
```

The command argument `passwdlink` did not contain `/`, `./`, `~`, or wildcard characters, so it was not treated as a path candidate during policy checks. The shell then executed `cat`, and the operating system followed the symlink to the forbidden target.

This hotfix closes that gap by extending path candidate detection for filesystem-oriented commands. If a bareword operand resolves to an existing filesystem entry, it is now checked against the path ACL before the command is allowed to act on it.

## Why this matters

`lshell` is a restricted shell. Its path policy is part of the security boundary. If a user can stay inside an allowed directory but still reach a forbidden target by hiding the target behind a local symlink, the boundary is no longer reliable.

This is not just a cosmetic issue or an edge-case parser mismatch. It is a real path policy bypass with practical impact:

1. a restricted user can read files outside the allowed roots
2. the bypass does not require direct mention of the forbidden path in the command line
3. the old guard logic can be defeated using normal shell and filesystem behavior

## Conditions required for the old bypass

The old behavior was exploitable when all of the following were true:

1. the policy allowed a file-oriented command such as `cat`
2. the user could work inside an allowed directory
3. a symlink with a plain name existed inside that allowed directory
4. the symlink target pointed to a location outside the allowed path roots

Example:

1. path policy allows `/tmp/allowed-dir`
2. `cat` is in the allow list
3. `/tmp/allowed-dir/passwdlink` points to `/etc/passwd`
4. user runs `cat passwdlink`

## What happened before this fix

The old execution chain looked like this:

1. `check_path(...)` called `_path_tokens_from_line(...)` to extract path-like operands
2. `_path_tokens_from_line(...)` only considered arguments that looked like paths on their face
3. a bareword such as `passwdlink` was skipped
4. no canonical path check happened for that operand
5. the command was executed
6. the called program followed the symlink and reached the forbidden target

Relevant code references:

- `lshell/sec.py:580-632`
- `lshell/sec.py:635-674`

The core reason was the old shape-based heuristic:

- `lshell/sec.py:446-456` before this hotfix only recognized explicit path markers such as `/`, `~`, `.` and wildcards

## What this hotfix changes

This hotfix keeps the existing path-like checks, but adds one more guarded path:

1. for commands that normally act on filesystem operands, bareword arguments are now inspected
2. if such a bareword resolves to an existing filesystem entry, it is treated as a path candidate
3. that candidate is then checked against the same ACL logic already used for explicit paths

The implementation is intentionally command-aware instead of globally aggressive.

### New command-aware path candidate logic

The hotfix introduces a dedicated set of filesystem-oriented commands:

- `lshell/sec.py:30-68`

It also adds helper functions to decide whether a plain argument should be promoted into a path candidate:

- `_safe_lexists(...)` avoids crashes on malformed values:
  - `lshell/sec.py:229-234`
- `_references_existing_path(...)` resolves a bareword relative to the current directory and checks whether it points to a real filesystem entry:
  - `lshell/sec.py:512-519`
- `_should_check_bareword_path_operand(...)` limits this behavior to filesystem-oriented commands and ignores options and plain numeric literals:
  - `lshell/sec.py:529-537`

Finally, `_path_tokens_from_line(...)` now includes a bareword operand when either of these is true:

1. it already looks like a path
2. it is a bareword that resolves to an existing filesystem entry for a filesystem-oriented command

Code reference:

- `lshell/sec.py:609-624`

## Why `echo passwdlink` is still allowed

This is intentional.

`echo` does not open files, follow symlinks, or perform filesystem actions on its arguments. It only prints text. Blocking `echo passwdlink` just because a file named `passwdlink` exists in the current directory would create false positives and degrade normal shell behavior.

This hotfix therefore does **not** make "every existing bareword" a path. It only upgrades barewords into path candidates when the receiving command is filesystem-oriented.

That design matters for both correctness and reviewability:

1. `cat passwdlink` must be denied because `cat` will dereference and read
2. `echo passwdlink` should remain allowed because `echo` only prints a literal argument

The guard is action-aware, not existence-aware in isolation.

Regression coverage for that exact distinction was added here:

- `test/test_security_attack_surface_unit_part2.py:837-869`

## How the fix was validated

Three layers of regression coverage were added around the fix.

### 1. Direct unit coverage for path token extraction and guard behavior

This verifies:

1. `cat passwdlink` is denied
2. `echo passwdlink` remains allowed

Code reference:

- `test/test_security_attack_surface_unit_part2.py:837-869`

### 2. Canonical authorizer coverage

This verifies that the v2 authorizer path also denies the same bareword symlink escape, not just the direct legacy helper path.

Code reference:

- `test/test_engine_security_regressions_unit.py:110-133`

### 3. End-to-end functional coverage

This verifies the full interactive shell behavior:

1. move into an allowed directory
2. attempt `cat passwdlink`
3. confirm that the shell reports `forbidden path: "/etc/passwd"`
4. confirm that the forbidden file content does not leak

Code reference:

- `test/test_security_hardening_functional.py:194-210`

## Test results used for this hotfix

The hotfix branch was validated with the following targeted suites:

```text
166 passed in 7.42s
```

This included:

1. attack-surface regression tests
2. engine authorization regression tests
3. functional hardening tests
4. path handling tests
5. property-based security tests

## Development status on 2026-06-17

After the first hotfix, a deeper review found that the same bareword symlink bypass could still be reached through other file-oriented text filters.

The practical examples were:

```bash
awk 1 passwdlink
sed -n 1p passwdlink
sort passwdlink
```

In these cases, `passwdlink` was still a simple bareword. If it was a symlink to `/etc/passwd`, and the user was inside an allowed directory, the older hotfix only blocked the already covered command family and did not fully model these text-filter operands.

The branch `hotfix/path-acl-symlink-guard` was continued instead of opening a new PR. The new work does the following:

1. merges the current `release` branch into the hotfix branch
2. extends command-aware path operand handling for `awk`, `gawk`, `mawk`, `nawk`, `sed`, `gsed`, and `sort`
3. keeps inline `awk` and `sed` programs from being treated as files when they are syntax operands
4. still checks `awk -f FILE` and `sed -f FILE`, because those operands are script files and must obey Path ACL
5. updates legacy functional tests that read files from `test/testfiles` so they explicitly allow that fixture directory through `--path`
6. fast-forwards `release` to the updated hotfix result

Important code and test references after the extension:

- `lshell/sec.py`
- `test/test_security_attack_surface_unit_part2.py`
- `test/test_engine_security_regressions_unit.py`
- `test/test_file_extension.py`
- `test/test_regex.py`

The final full-suite validation before merging into `release` was:

```bash
.venv/bin/pytest -q
```

Result:

```text
554 passed, 62 subtests passed in 109.30s
```

The `release` branch was then fast-forwarded from `c33e03c` to `9e63ebf`.

## Scope of the fix

This PR is intentionally narrow.

It fixes the verified bypass where a filesystem-oriented command could act on a forbidden target hidden behind a bareword symlink in an allowed directory.

It does not try to redesign all operand typing in one step. It keeps the change small enough for a hotfix review while still adding explicit regression coverage.

## Important review points

Reviewers can focus on these questions:

1. Is the new bareword promotion limited to commands that actually act on filesystem entries?
2. Does the new logic correctly resolve relative barewords against the current working directory?
3. Does the same ACL enforcement now apply to symlink-backed bareword operands before the action happens?
4. Does the hotfix avoid breaking non-filesystem commands such as `echo`?
5. Do the added tests cover both the exploit path and the intended non-regression behavior?

## Main code references

- `lshell/sec.py:30-68`
- `lshell/sec.py:229-234`
- `lshell/sec.py:512-537`
- `lshell/sec.py:580-632`
- `lshell/sec.py:635-674`
- `test/test_security_attack_surface_unit_part2.py:837-869`
- `test/test_engine_security_regressions_unit.py:110-133`
- `test/test_security_hardening_functional.py:194-210`

## Branch and commit

- Branch: `hotfix/path-acl-symlink-guard`
- Original bareword symlink commit: `024b9b903cc853163dabfc0af685af2d1d40710a`
- Extended text-filter fix commit: `b9a59dc`
- Release merge/result commit: `9e63ebf`
- Release status: fast-forwarded to the updated hotfix result
